### PR TITLE
221/update forecast national route

### DIFF
--- a/src/national.py
+++ b/src/national.py
@@ -40,11 +40,11 @@ def get_national_forecast(
 ) -> Union[Forecast, List[ForecastValue]]:
     """Get the National Forecast
 
-    This route aggregrates data from all GSP forecasts in Great Britain,
-    creating a national, 8-hour,
-    solar generation forecast in 30-minute intervals.
+    This route returns the most recent forecast for each _target_time_.
+
     The _forecast_horizon_minutes_ parameter allows
-    a user to query for a forecast closer than 8 hours to the target time.
+    a user to query for a forecast that is made this number, or horizon, of
+    minutes before the _target_time_.
 
     For example, if the target time is 10am today, the forecast made at 2am
     today is the 8-hour forecast for 10am, and the forecast made at 6am for
@@ -64,15 +64,19 @@ def get_national_forecast(
     save_api_call_to_db(session=session, user=user, request=request)
 
     logger.debug("Getting forecast.")
-    national_forecast_values = get_latest_forecast_values_for_a_specific_gsp_from_database(
-        session=session, gsp_id=0, forecast_horizon_minutes=forecast_horizon_minutes
+    national_forecast_values = (
+        get_latest_forecast_values_for_a_specific_gsp_from_database(
+            session=session, gsp_id=0, forecast_horizon_minutes=forecast_horizon_minutes
+        )
     )
 
     logger.debug(
         f"Got national forecasts with {len(national_forecast_values)} forecast values. "
         f"Now adjusting by at most {adjust_limit} MW"
     )
-    national_forecast_values = [f.adjust(limit=adjust_limit) for f in national_forecast_values]
+    national_forecast_values = [
+        f.adjust(limit=adjust_limit) for f in national_forecast_values
+    ]
 
     return national_forecast_values
 
@@ -107,7 +111,9 @@ def get_national_pvlive(
     - **regime**: can choose __in-day__ or __day-after__
     """
 
-    logger.info(f"Get national PV Live estimates values " f"for regime {regime} for  {user}")
+    logger.info(
+        f"Get national PV Live estimates values " f"for regime {regime} for  {user}"
+    )
 
     save_api_call_to_db(session=session, user=user, request=request)
 

--- a/src/national.py
+++ b/src/national.py
@@ -64,19 +64,15 @@ def get_national_forecast(
     save_api_call_to_db(session=session, user=user, request=request)
 
     logger.debug("Getting forecast.")
-    national_forecast_values = (
-        get_latest_forecast_values_for_a_specific_gsp_from_database(
-            session=session, gsp_id=0, forecast_horizon_minutes=forecast_horizon_minutes
-        )
+    national_forecast_values = get_latest_forecast_values_for_a_specific_gsp_from_database(
+        session=session, gsp_id=0, forecast_horizon_minutes=forecast_horizon_minutes
     )
 
     logger.debug(
         f"Got national forecasts with {len(national_forecast_values)} forecast values. "
         f"Now adjusting by at most {adjust_limit} MW"
     )
-    national_forecast_values = [
-        f.adjust(limit=adjust_limit) for f in national_forecast_values
-    ]
+    national_forecast_values = [f.adjust(limit=adjust_limit) for f in national_forecast_values]
 
     return national_forecast_values
 
@@ -111,9 +107,7 @@ def get_national_pvlive(
     - **regime**: can choose __in-day__ or __day-after__
     """
 
-    logger.info(
-        f"Get national PV Live estimates values " f"for regime {regime} for  {user}"
-    )
+    logger.info(f"Get national PV Live estimates values " f"for regime {regime} for  {user}")
 
     save_api_call_to_db(session=session, user=user, request=request)
 

--- a/src/national.py
+++ b/src/national.py
@@ -95,6 +95,7 @@ def get_national_pvlive(
 
     Returns a series of real-time solar energy generation readings from
     PV_Live for all of Great Britain.
+    
     _In-day_ values are PV generation estimates for the current day,
     while _day-after_ values are
     updated PV generation truths for the previous day along with

--- a/src/national.py
+++ b/src/national.py
@@ -43,36 +43,21 @@ def get_national_forecast(
 ) -> Union[Forecast, List[ForecastValue]]:
     """Get the National Forecast
 
-    This route aggregrates data from all GSP forecasts and creates an 8-hour solar energy
-    generation forecast  in 30-minute interval for all of GB.
+    This route aggregrates data from all GSP forecasts in Great Britain,
+    creating a national, 8-hour,
+    solar generation forecast in 30-minute intervals.
+    The _forecast_horizon_minutes_ parameter allows
+    a user to query for a forecast closer than 8 hours to the target time.
 
-    1. Get __recent solar forecast__ for the UK for today and yesterday
-    with system details.
-        - The return object is a solar forecast with forecast details.
-        -The forecast object is returned with expected megawatt generation for the UK
-        for the upcoming 8 hours at every 30-minute interval (targetTime).
-        - Set __only_forecast_values__ ==> FALSE
-        - Setting __historic__ parameter to TRUE returns an object with data
-        from yesterday and today
-
-    2. Get __ONLY__ forecast values for solar national forecast.
-        - Set __only_forecast_values__ to TRUE
-        - Setting a __forecast_horizon_minutes__ parameter retrieves the latest forecast
-        a given set of minutes before the target time.
-        - Return object is a simplified forecast object with __targetTimes__ and
-        __expectedPowerGenerationMegawatts__ at 30-minute intervals.
-        - NB: __historic__ parameter __will not__ work when __only_forecast_values__= TRUE
-
-    Please see the __Forecast__ and __ForecastValue__ schema below for full metadata details.
+    For example, if the target time is 10am today, the forecast made at 2am
+    today is the 8-hour forecast for 10am, and the forecast made at 6am for
+    10am today is the 4-hour forecast for 10am.
 
     #### Parameters
-    - historic: boolean => TRUE returns yesterday's forecasts in addition to today's forecast
-    - only_forecast_values => TRUE returns solar national forecast values
-    - forecast_horizon_minutes: optional forecast horizon in minutes (ex. 35 returns
-    the latest forecast made 35 minutes before the target time)
+    - **forecast_horizon_minutes**: optional forecast horizon in minutes (ex.
+    60 returns the forecast made an hour before the target time)
 
     """
-
     logger.debug("Get national forecasts")
 
     save_api_call_to_db(session=session, user=user, request=request)
@@ -124,32 +109,20 @@ def get_national_pvlive(
     session: Session = Depends(get_session),
     user: Auth0User = Security(get_user()),
 ) -> List[NationalYield]:
-    """### Get national PV_Live values for yesterday and today
+    """### Get national PV_Live values for yesterday and/or today
 
-    The return object is a series of real-time solar energy generation readings from PV_Live.
+    Returns a series of real-time solar energy generation readings from
+    PV_Live for all of Great Britain.
+    _In-day_ values are PV generation estimates for the current day,
+    while _day-after_ values are
+    updated PV generation truths for the previous day along with
+    _in-day_ estimates for the current day.
 
-    PV_Live is Sheffield's API that reports real-time PV data. These readings are updated throughout
-    the day, reporting the most accurate finalized readings the following day at 10:00 UTC.
-
-    See the __GSPYield__ schema for metadata details.
-
-    Check out [Sheffield Solar PV_Live](https://www.solarsheffield.ac.uk/pvlive/) for
-    more details.
-
-    The OCF Forecast is trying to predict the PV_Live 'day-after' value.
-
-    This route has the __regime__ parameter that lets you look at values __in-day__ or
-    __day-after__(most accurate reading). __Day-after__ values are updated __in-day__ values.
-    __In-day__ gives you all the readings from the day before up to the most recent
-    reported national yield. __Day_after__ reports all the readings from the previous day.
-    For example, a day-after regime request made on 08/09/2022 returns updated national yield
-    for 07/09/2022. The 08/09/2022 __day-after__ values then become available at 10:00 UTC
-    on 09/09/2022.
-
-    If regime is not specificied, the most up-to-date national yield is returned.
+    If nothing is set for the _regime_ parameter, the route will return
+    _in-day_ values for the current day.
 
     #### Parameters
-    - regime: can choose __in-day__ or __day-after__
+    - **regime**: can choose __in-day__ or __day-after__
     """
 
     logger.info(f"Get national PV Live estimates values " f"for regime {regime} for  {user}")

--- a/src/national.py
+++ b/src/national.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm.session import Session
 from auth_utils import get_auth_implicit_scheme, get_user
 from cache import cache_response
 from database import (
-    get_forecasts_for_a_specific_gsp_from_database,
     get_latest_forecast_values_for_a_specific_gsp_from_database,
     get_session,
     get_truth_values_for_a_specific_gsp_from_database,
@@ -65,15 +64,19 @@ def get_national_forecast(
     save_api_call_to_db(session=session, user=user, request=request)
 
     logger.debug("Getting forecast.")
-    national_forecast_values = get_latest_forecast_values_for_a_specific_gsp_from_database(
-        session=session, gsp_id=0, forecast_horizon_minutes=forecast_horizon_minutes
+    national_forecast_values = (
+        get_latest_forecast_values_for_a_specific_gsp_from_database(
+            session=session, gsp_id=0, forecast_horizon_minutes=forecast_horizon_minutes
+        )
     )
 
     logger.debug(
         f"Got national forecasts with {len(national_forecast_values)} forecast values. "
         f"Now adjusting by at most {adjust_limit} MW"
     )
-    national_forecast_values = [f.adjust(limit=adjust_limit) for f in national_forecast_values]
+    national_forecast_values = [
+        f.adjust(limit=adjust_limit) for f in national_forecast_values
+    ]
 
     return national_forecast_values
 
@@ -108,7 +111,9 @@ def get_national_pvlive(
     - **regime**: can choose __in-day__ or __day-after__
     """
 
-    logger.info(f"Get national PV Live estimates values " f"for regime {regime} for  {user}")
+    logger.info(
+        f"Get national PV Live estimates values " f"for regime {regime} for  {user}"
+    )
 
     save_api_call_to_db(session=session, user=user, request=request)
 

--- a/src/national.py
+++ b/src/national.py
@@ -95,7 +95,7 @@ def get_national_pvlive(
 
     Returns a series of real-time solar energy generation readings from
     PV_Live for all of Great Britain.
-    
+
     _In-day_ values are PV generation estimates for the current day,
     while _day-after_ values are
     updated PV generation truths for the previous day along with

--- a/src/tests/test_national.py
+++ b/src/tests/test_national.py
@@ -27,9 +27,7 @@ def test_read_latest_national_values(db_session, api_client):
     forecast.model = model
 
     db_session.add(forecast)
-    update_all_forecast_latest(
-        forecasts=[forecast], session=db_session, model_name="cnn"
-    )
+    update_all_forecast_latest(forecasts=[forecast], session=db_session, model_name="cnn")
 
     app.dependency_overrides[get_session] = lambda: db_session
 

--- a/src/tests/test_national.py
+++ b/src/tests/test_national.py
@@ -3,12 +3,7 @@ from datetime import datetime, timezone
 
 from freezegun import freeze_time
 from nowcasting_datamodel.fake import make_fake_national_forecast
-from nowcasting_datamodel.models import (
-    ForecastValue,
-    GSPYield,
-    Location,
-    LocationSQL,
-)
+from nowcasting_datamodel.models import ForecastValue, GSPYield, Location, LocationSQL
 from nowcasting_datamodel.read.read import get_model
 from nowcasting_datamodel.save.update import update_all_forecast_latest
 

--- a/src/tests/test_national.py
+++ b/src/tests/test_national.py
@@ -3,7 +3,12 @@ from datetime import datetime, timezone
 
 from freezegun import freeze_time
 from nowcasting_datamodel.fake import make_fake_national_forecast
-from nowcasting_datamodel.models import Forecast, ForecastValue, GSPYield, Location, LocationSQL
+from nowcasting_datamodel.models import (
+    ForecastValue,
+    GSPYield,
+    Location,
+    LocationSQL,
+)
 from nowcasting_datamodel.read.read import get_model
 from nowcasting_datamodel.save.update import update_all_forecast_latest
 
@@ -22,7 +27,9 @@ def test_read_latest_national_values(db_session, api_client):
     forecast.model = model
 
     db_session.add(forecast)
-    update_all_forecast_latest(forecasts=[forecast], session=db_session, model_name="cnn")
+    update_all_forecast_latest(
+        forecasts=[forecast], session=db_session, model_name="cnn"
+    )
 
     app.dependency_overrides[get_session] = lambda: db_session
 

--- a/src/tests/test_national.py
+++ b/src/tests/test_national.py
@@ -11,23 +11,7 @@ from database import get_session
 from main import app
 
 
-def test_read_latest_national(db_session, api_client):
-    """Check main solar/GB/national/forecast route works"""
-
-    forecast = make_fake_national_forecast(
-        session=db_session, t0_datetime_utc=datetime.now(tz=timezone.utc)
-    )
-    db_session.add(forecast)
-
-    app.dependency_overrides[get_session] = lambda: db_session
-
-    response = api_client.get("/v0/solar/GB/national/forecast/")
-    assert response.status_code == 200
-
-    _ = Forecast(**response.json())
-
-
-def test_read_latest_national_historic_forecast_value(db_session, api_client):
+def test_read_latest_national_values(db_session, api_client):
     """Check main solar/GB/national/forecast route works"""
 
     model = get_model(db_session, name="cnn", version="0.0.1")
@@ -42,27 +26,10 @@ def test_read_latest_national_historic_forecast_value(db_session, api_client):
 
     app.dependency_overrides[get_session] = lambda: db_session
 
-    response = api_client.get("/v0/solar/GB/national/forecast/?only_forecast_values=True")
+    response = api_client.get("/v0/solar/GB/national/forecast")
     assert response.status_code == 200
 
     _ = [ForecastValue(**f) for f in response.json()]
-
-
-def test_read_latest_national_historic(db_session, api_client):
-    """Check main solar/GB/national/forecast route works"""
-
-    forecast = make_fake_national_forecast(
-        session=db_session, t0_datetime_utc=datetime.now(tz=timezone.utc)
-    )
-    db_session.add(forecast)
-    update_all_forecast_latest(forecasts=[forecast], session=db_session)
-
-    app.dependency_overrides[get_session] = lambda: db_session
-
-    response = api_client.get("/v0/solar/GB/national/forecast/?historic=True")
-    assert response.status_code == 200
-
-    _ = Forecast(**response.json())
 
 
 @freeze_time("2022-01-01")


### PR DESCRIPTION
# Pull Request

## Description

This PR does the following: 
- updates the text for the API docs for the `Get National Forecast` and the `Get PVLive National Forecast` routes (see screenshots below)
-  tidies up the `get national forecast` route by removing the `historic` and `only_values` options
- updates the tests for the national routes

`Get National Forecast`
<img width="603" alt="Screenshot 2023-06-27 at 12 29 15" src="https://github.com/openclimatefix/uk-pv-national-gsp-api/assets/86949265/92c6c910-f8f2-42a1-86cf-648e37f337e3">

`Get PVLive National Forecast`
<img width="598" alt="Screenshot 2023-06-27 at 12 30 12" src="https://github.com/openclimatefix/uk-pv-national-gsp-api/assets/86949265/dd621f63-307d-478a-8b6c-8b33a264149e">

Fixes #221 

## How Has This Been Tested?

Ran the code locally to see doc formatting and ran tests using docker. 

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
