### PR TITLE
Update GSP forecast route

### DIFF
--- a/src/gsp.py
+++ b/src/gsp.py
@@ -69,7 +69,6 @@ def get_all_available_forecasts(
     return forecasts
 
 
-
 @router.get(
     "/forecast/{gsp_id}",
     response_model=Union[Forecast, List[ForecastValue]],
@@ -96,6 +95,7 @@ def get_forecasts_for_a_specific_gsp_old_route(
         user=user,
     )
 
+
 @router.get(
     "/{gsp_id}/forecast",
     response_model=Union[Forecast, List[ForecastValue]],
@@ -110,10 +110,10 @@ def get_forecasts_for_a_specific_gsp(
     user: Auth0User = Security(get_user()),
 ) -> Union[Forecast, List[ForecastValue]]:
     """### Get recent forecast values for a specific GSP
-   
+
     Returns an 8-hour solar generation forecast for a specific GSP with option
-    to change the forecast horizon. 
-    
+    to change the forecast horizon.
+
     The _forecast_horizon_minutes_ parameter allows
     a user to query for a forecast closer than 8 hours to the target time.
 
@@ -133,10 +133,10 @@ def get_forecasts_for_a_specific_gsp(
     logger.info(f"This is for user {user}")
 
     forecast_values_for_specific_gsp = get_latest_forecast_values_for_a_specific_gsp_from_database(
-            session=session,
-            gsp_id=gsp_id,
-            forecast_horizon_minutes=forecast_horizon_minutes,
-        )
+        session=session,
+        gsp_id=gsp_id,
+        forecast_horizon_minutes=forecast_horizon_minutes,
+    )
 
     logger.debug("Got forecast values for a specific gsp.")
 

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -83,7 +83,7 @@ def get_forecasts_for_a_specific_gsp_old_route(
     forecast_horizon_minutes: Optional[int] = None,
     user: Auth0User = Security(get_user()),
 ) -> Union[Forecast, List[ForecastValue]]:
-    get_forecasts_for_a_specific_gsp(
+    return get_forecasts_for_a_specific_gsp(
         request=request,
         gsp_id=gsp_id,
         session=session,
@@ -186,7 +186,7 @@ def get_truths_for_a_specific_gsp_old_route(
     session: Session = Depends(get_session),
     user: Auth0User = Security(get_user()),
 ) -> List[GSPYield]:
-    get_forecasts_for_a_specific_gsp(
+    return get_truths_for_a_specific_gsp(
         request=request,
         gsp_id=gsp_id,
         regime=regime,

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -133,10 +133,10 @@ def get_forecasts_for_a_specific_gsp(
 
     logger.info(f"Get forecasts for gsp id {gsp_id} forecast of forecast with only values.")
     logger.info(f"This is for user {user}")
-    
+
     if gsp_id > GSP_TOTAL:
         return Response(None, status.HTTP_204_NO_CONTENT)
-    
+
     forecast_values_for_specific_gsp = get_latest_forecast_values_for_a_specific_gsp_from_database(
         session=session,
         gsp_id=gsp_id,

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -113,7 +113,7 @@ def get_forecasts_for_a_specific_gsp(
 ) -> Union[Forecast, List[ForecastValue]]:
     """### Get recent forecast values for a specific GSP
 
-    This route returns the most recent forecast for each _target_time_ for a 
+    This route returns the most recent forecast for each _target_time_ for a
     specific GSP.
 
     The _forecast_horizon_minutes_ parameter allows
@@ -228,7 +228,7 @@ def get_truths_for_a_specific_gsp(
     from __PV_Live__ for a single GSP.
 
     Setting the _regime_ parameter to _day-after_ includes
-    the previous day's truth values for the GSPs. 
+    the previous day's truth values for the GSPs.
 
     If _regime_ is not specified, the parameter defaults to _in-day_.
 

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -17,7 +17,6 @@ from sqlalchemy.orm.session import Session
 from auth_utils import get_auth_implicit_scheme, get_user
 from cache import cache_response
 from database import (
-    get_forecasts_for_a_specific_gsp_from_database,
     get_forecasts_from_database,
     get_latest_forecast_values_for_a_specific_gsp_from_database,
     get_session,
@@ -51,10 +50,11 @@ def get_all_available_forecasts(
 ) -> ManyForecasts:
     """### Get the latest information for all available forecasts for all GSPs
 
-    The return object contains a forecast object with system details and forecast values for all GSPs.
+    The return object contains a forecast object with system details and
+    forecast values for all GSPs.
 
-    This request may take a longer time to load because a lot of data is being pulled from the
-    database.
+    This request may take a longer time to load because a lot of data is being
+    pulled from the database.
 
     #### Parameters
     - **historic**: boolean value set to True returns the forecasts of yesterday along with today's
@@ -88,6 +88,7 @@ def get_forecasts_for_a_specific_gsp_old_route(
     forecast_horizon_minutes: Optional[int] = None,
     user: Auth0User = Security(get_user()),
 ) -> Union[Forecast, List[ForecastValue]]:
+    """Redirects old API route to new route /v0/solar/GB/gsp/{gsp_id}/forecast"""
     return get_forecasts_for_a_specific_gsp(
         request=request,
         gsp_id=gsp_id,
@@ -196,6 +197,7 @@ def get_truths_for_a_specific_gsp_old_route(
     session: Session = Depends(get_session),
     user: Auth0User = Security(get_user()),
 ) -> List[GSPYield]:
+    """Redirects old API route to new route /v0/solar/GB/gsp/{gsp_id}/pvlive"""
     return get_truths_for_a_specific_gsp(
         request=request,
         gsp_id=gsp_id,
@@ -205,7 +207,7 @@ def get_truths_for_a_specific_gsp_old_route(
     )
 
 
-# corresponds to API route /v0/solar/GB/gsp/pvlive/{gsp_id}
+# corresponds to API route /v0/solar/GB/gsp/{gsp_id}/pvlive
 @router.get(
     "/{gsp_id}/pvlive",
     response_model=List[GSPYield],
@@ -225,8 +227,8 @@ def get_truths_for_a_specific_gsp(
     The return object is a series of real-time solar energy generation
     from PV_Live for a single GSP.
 
-    Setting the __regime__ parameter to __day-after__ includes
-    the previous day's truth values for the GSPs. The default is __in-day__.
+    Setting the _regime_ parameter to _day-after_ includes
+    the previous day's truth values for the GSPs. The default is _in-day_.
 
     If regime is not specified, the most up-to-date GSP yield is returned.
 

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -48,7 +48,7 @@ def get_all_available_forecasts(
     session: Session = Depends(get_session),
     user: Auth0User = Security(get_user()),
 ) -> ManyForecasts:
-    """### Get the latest information for all available forecasts for all GSPs
+    """### Get all forecasts for all GSPs
 
     The return object contains a forecast object with system details and
     forecast values for all GSPs.
@@ -57,9 +57,8 @@ def get_all_available_forecasts(
     pulled from the database.
 
     #### Parameters
-    - **historic**: boolean value set to True returns the forecasts of yesterday along with today's
-    forecasts for all GSPs
-
+    - **historic**: boolean that defaults to `true`, returning yesterday's and
+    today's forecasts for all GSPs
     """
 
     save_api_call_to_db(session=session, user=user, request=request)
@@ -114,18 +113,19 @@ def get_forecasts_for_a_specific_gsp(
 ) -> Union[Forecast, List[ForecastValue]]:
     """### Get recent forecast values for a specific GSP
 
-    Returns an 8-hour solar generation forecast for a specific GSP with option
-    to change the forecast horizon.
+    This route returns the most recent forecast for each _target_time_ for a 
+    specific GSP.
 
     The _forecast_horizon_minutes_ parameter allows
-    a user to query for a forecast closer than 8 hours to the target time.
+    a user to query for a forecast that is made this number, or horizon, of
+    minutes before the _target_time_.
 
     For example, if the target time is 10am today, the forecast made at 2am
     today is the 8-hour forecast for 10am, and the forecast made at 6am for
     10am today is the 4-hour forecast for 10am.
 
     #### Parameters
-    - **gsp_id**: **gsp_id** of the desired forecast
+    - **gsp_id**: *gsp_id* of the desired forecast
     - **forecast_horizon_minutes**: optional forecast horizon in minutes (ex. 60
     returns the latest forecast made 60 minutes before the target time)
     """
@@ -162,15 +162,15 @@ def get_truths_for_all_gsps(
     session: Session = Depends(get_session),
     user: Auth0User = Security(get_user()),
 ) -> List[LocationWithGSPYields]:
-    """### Get PV_Live values for all GSPs for yesterday and/or today
+    """### Get PV_Live values for all GSPs for yesterday and today
 
     The return object is a series of real-time PV generation estimates or
-    truth values from PV_Live for all GSPs.
+    truth values from __PV_Live__ for all GSPs.
 
     Setting the _regime_ parameter to _day-after_ includes
-    the previous day's truth values for the GSPs. The default is _in-day__.
+    the previous day's truth values for the GSPs.
 
-    If regime is not specified, the most up-to-date GSP yield is returned.
+    If _regime_ is not specified, the parameter defaults to _in-day_.
 
     #### Parameters
     - **regime**: can choose __in-day__ or __day-after__
@@ -225,15 +225,15 @@ def get_truths_for_a_specific_gsp(
     """### Get PV_Live values for a specific GSP for yesterday and today
 
     The return object is a series of real-time solar energy generation
-    from PV_Live for a single GSP.
+    from __PV_Live__ for a single GSP.
 
     Setting the _regime_ parameter to _day-after_ includes
-    the previous day's truth values for the GSPs. The default is _in-day_.
+    the previous day's truth values for the GSPs. 
 
-    If regime is not specified, the most up-to-date GSP yield is returned.
+    If _regime_ is not specified, the parameter defaults to _in-day_.
 
     #### Parameters
-    - **gsp_id**: gsp_id of the requested forecast
+    - **gsp_id**: _gsp_id_ of the requested forecast
     - **regime**: can choose __in-day__ or __day-after__
     """
 

--- a/src/system.py
+++ b/src/system.py
@@ -14,6 +14,7 @@ from auth_utils import get_auth_implicit_scheme, get_user
 from cache import cache_response
 from database import get_gsp_system, get_session
 
+# flake8: noqa: E501
 logger = structlog.stdlib.get_logger()
 
 
@@ -45,14 +46,14 @@ def get_gsp_boundaries_from_eso_wgs84() -> gpd.GeoDataFrame:
 def get_gsp_boundaries(
     user: Auth0User = Security(get_user()),
 ) -> dict:
-    """### Get one GSP boundary for a specific GSP
+    """### Get GSP boundaries
 
-    This route is still under construction...
+    Returns an object with GSP boundaries provided by National Grid ESO.
 
-    [This is a wrapper around the dataset]
-    (https://data.nationalgrideso.com/systemgis-boundaries-for-gb-grid-supply-points).
+    [This is a wrapper around the dataset](https://data.nationalgrideso.com/systemgis-boundaries-for-gb-grid-supply-points).
 
-    Returns an object that is in EPSG:4326 (ie. latitude & longitude coordinates).
+    The return object is in EPSG:4326 (ie. contains latitude & longitude
+    coordinates).
 
     """
 
@@ -72,25 +73,18 @@ def get_gsp_boundaries(
     dependencies=[Depends(get_auth_implicit_scheme())],
 )
 @cache_response
-def get_systems(
+def get_system_details(
     session: Session = Depends(get_session),
     gsp_id: Optional[int] = None,
     user: Auth0User = Security(get_user()),
 ) -> List[Location]:
     """### Get system details for a single GSP or all GSPs
 
-    Returns an object with the system details of a given GSP using the
-    gsp_id parameter.
-
-    Provide one gsp_id to return system details for that GSP, otherwise details for ALL
-    grid systems will be returned.
-
-    Please see __Location__ schema for metadata details.
+    Returns an object with system details of a given GSP using the
+    _gsp_id_ query parameter, otherwise details for all supply points are provided.
 
     #### Parameters
-    - gsp_id: gsp_id of the requested system
-    - NB: If no parameter is entered, system details for all 300+ GSPs are returned.
-
+    - **gsp_id**: gsp_id of the requested system
     """
 
     logger.info(f"Get GSP systems for {gsp_id=} for {user}")

--- a/src/tests/test_gsp.py
+++ b/src/tests/test_gsp.py
@@ -72,7 +72,7 @@ def test_read_latest_gsp_id_greater_than_total(db_session, api_client):
 def test_read_latest_gsp_id_equal_to_total(db_session, api_client):
     """Check that request with gsp_id<318 returns 200"""
 
-    forecasts = make_fake_forecasts(gsp_ids=[317], session=db_session)
+    forecasts = make_fake_forecasts(gsp_ids=[317], session=db_session, add_latest=True)
     db_session.add_all(forecasts)
 
     app.dependency_overrides[get_session] = lambda: db_session

--- a/src/tests/test_gsp.py
+++ b/src/tests/test_gsp.py
@@ -31,7 +31,7 @@ def test_read_latest_one_gsp(db_session, api_client):
     response = api_client.get("/v0/solar/GB/gsp/1/forecast")
 
     assert response.status_code == 200
-  
+
     _ = [ForecastValue(**f) for f in response.json()]
 
 

--- a/src/tests/test_gsp.py
+++ b/src/tests/test_gsp.py
@@ -22,8 +22,9 @@ from main import app
 def test_read_latest_one_gsp(db_session, api_client):
     """Check main solar/GB/gsp/{gsp_id}/forecast route works"""
 
-    forecasts = make_fake_forecasts(gsp_ids=list(range(0, 10)), session=db_session)
+    forecasts = make_fake_forecasts(gsp_ids=list(range(0, 2)), session=db_session, add_latest=True)
     db_session.add_all(forecasts)
+    db_session.commit()
 
     app.dependency_overrides[get_session] = lambda: db_session
 

--- a/src/tests/test_gsp.py
+++ b/src/tests/test_gsp.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from freezegun import freeze_time
 from nowcasting_datamodel.fake import make_fake_forecasts
 from nowcasting_datamodel.models import (
-    Forecast,
+    ForecastValue,
     GSPYield,
     Location,
     LocationSQL,
@@ -20,18 +20,18 @@ from main import app
 
 @freeze_time("2022-01-01")
 def test_read_latest_one_gsp(db_session, api_client):
-    """Check main solar/GB/gsp/forecast/{gsp_id} route works"""
+    """Check main solar/GB/gsp/{gsp_id}/forecast route works"""
 
     forecasts = make_fake_forecasts(gsp_ids=list(range(0, 10)), session=db_session)
     db_session.add_all(forecasts)
 
     app.dependency_overrides[get_session] = lambda: db_session
 
-    response = api_client.get("/v0/solar/GB/gsp/forecast/1")
+    response = api_client.get("/v0/solar/GB/gsp/1/forecast")
 
     assert response.status_code == 200
-
-    _ = Forecast(**response.json())
+  
+    _ = [ForecastValue(**f) for f in response.json()]
 
 
 def test_read_latest_all_gsp(db_session, api_client):

--- a/src/tests/test_gsp.py
+++ b/src/tests/test_gsp.py
@@ -81,7 +81,7 @@ def test_read_latest_gsp_id_equal_to_total(db_session, api_client):
 
     assert response.status_code == 200
 
-    _ = Forecast(**response.json())
+    _ = [ForecastValue(**f) for f in response.json()]
 
 
 def test_read_latest_all_gsp_normalized(db_session, api_client):

--- a/src/tests/test_merged_routes.py
+++ b/src/tests/test_merged_routes.py
@@ -14,7 +14,7 @@ from main import app
 def test_read_one_gsp(db_session, api_client):
     """Check main solar/GB/gsp/{gsp_id}/forecast route works"""
 
-    forecasts = make_fake_forecasts(gsp_ids=list(range(0, 10)), session=db_session)
+    forecasts = make_fake_forecasts(gsp_ids=list(range(0, 10)), session=db_session, add_latest=True)
     db_session.add_all(forecasts)
 
     app.dependency_overrides[get_session] = lambda: db_session
@@ -22,7 +22,7 @@ def test_read_one_gsp(db_session, api_client):
     response = api_client.get("/v0/solar/GB/gsp/1/forecast")
     assert response.status_code == 200
 
-    _ = ForecastValue(**response.json())
+    _ = [ForecastValue(**f) for f in response.json()]
 
 
 @freeze_time("2022-06-01")

--- a/src/tests/test_merged_routes.py
+++ b/src/tests/test_merged_routes.py
@@ -16,6 +16,7 @@ def test_read_one_gsp(db_session, api_client):
 
     forecasts = make_fake_forecasts(gsp_ids=list(range(0, 10)), session=db_session, add_latest=True)
     db_session.add_all(forecasts)
+    db_session.commit()
 
     app.dependency_overrides[get_session] = lambda: db_session
 

--- a/src/tests/test_merged_routes.py
+++ b/src/tests/test_merged_routes.py
@@ -10,7 +10,6 @@ from database import get_session
 from main import app
 
 
-
 @freeze_time("2022-06-01")
 def test_read_forecast_values_gsp(db_session, api_client):
     """Check main solar/GB/gsp/{gsp_id}/forecast route works"""

--- a/src/tests/test_merged_routes.py
+++ b/src/tests/test_merged_routes.py
@@ -10,21 +10,6 @@ from database import get_session
 from main import app
 
 
-@freeze_time("2022-01-01")
-def test_read_one_gsp(db_session, api_client):
-    """Check main solar/GB/gsp/{gsp_id}/forecast route works"""
-
-    forecasts = make_fake_forecasts(gsp_ids=list(range(0, 10)), session=db_session, add_latest=True)
-    db_session.add_all(forecasts)
-    db_session.commit()
-
-    app.dependency_overrides[get_session] = lambda: db_session
-
-    response = api_client.get("/v0/solar/GB/gsp/1/forecast")
-    assert response.status_code == 200
-
-    _ = [ForecastValue(**f) for f in response.json()]
-
 
 @freeze_time("2022-06-01")
 def test_read_forecast_values_gsp(db_session, api_client):

--- a/src/tests/test_merged_routes.py
+++ b/src/tests/test_merged_routes.py
@@ -12,41 +12,22 @@ from main import app
 
 @freeze_time("2022-01-01")
 def test_read_one_gsp(db_session, api_client):
-    """Check main solar/GB/gsp/forecast/{gsp_id} route works"""
+    """Check main solar/GB/gsp/{gsp_id}/forecast route works"""
 
     forecasts = make_fake_forecasts(gsp_ids=list(range(0, 10)), session=db_session)
     db_session.add_all(forecasts)
 
     app.dependency_overrides[get_session] = lambda: db_session
 
-    response = api_client.get("/v0/solar/GB/gsp/forecast/1")
+    response = api_client.get("/v0/solar/GB/gsp/1/forecast")
     assert response.status_code == 200
 
-    _ = Forecast(**response.json())
-
-
-def test_read_one_gsp_historic(db_session, api_client):
-    """Check main solar/GB/gsp/forecast/{gsp_id} route works with history"""
-
-    forecasts = make_fake_forecasts(
-        gsp_ids=list(range(0, 10)),
-        session=db_session,
-        t0_datetime_utc=datetime.now(tz=timezone.utc),
-    )
-    db_session.add_all(forecasts)
-    update_all_forecast_latest(forecasts=forecasts, session=db_session)
-
-    app.dependency_overrides[get_session] = lambda: db_session
-
-    response = api_client.get("/v0/solar/GB/gsp/forecast/2?historic=True")
-    assert response.status_code == 200
-
-    _ = Forecast(**response.json())
+    _ = ForecastValue(**response.json())
 
 
 @freeze_time("2022-06-01")
-def test_read_only_forecast_values_gsp(db_session, api_client):
-    """Check main solar/GB/gsp/forecast/{gsp_id} route works"""
+def test_read_forecast_values_gsp(db_session, api_client):
+    """Check main solar/GB/gsp/{gsp_id}/forecast route works"""
 
     forecast_value_1_sql = ForecastValueLatestSQL(
         target_time=datetime(2023, 6, 2), expected_power_generation_megawatts=1, gsp_id=1
@@ -72,7 +53,7 @@ def test_read_only_forecast_values_gsp(db_session, api_client):
 
     app.dependency_overrides[get_session] = lambda: db_session
 
-    response = api_client.get("/v0/solar/GB/gsp/forecast/1?only_forecast_values=true")
+    response = api_client.get("/v0/solar/GB/gsp/1/forecast")
     assert response.status_code == 200
 
     r_json = response.json()

--- a/src/tests/test_merged_routes.py
+++ b/src/tests/test_merged_routes.py
@@ -1,10 +1,9 @@
 """ Test for main app """
-from datetime import datetime, timezone
+from datetime import datetime
 
 from freezegun import freeze_time
-from nowcasting_datamodel.fake import make_fake_forecast, make_fake_forecasts
-from nowcasting_datamodel.models import Forecast, ForecastValue, ForecastValueLatestSQL
-from nowcasting_datamodel.save.update import update_all_forecast_latest
+from nowcasting_datamodel.fake import make_fake_forecast
+from nowcasting_datamodel.models import ForecastValue, ForecastValueLatestSQL
 
 from database import get_session
 from main import app


### PR DESCRIPTION
# Pull Request

## Description
This PR does the following: 

- tidies up the GSP forecast API routes so they're more RESTful
- updates tests for the routes and removes unnecessary or duplicate tests
- updates the API documentation for the GSP forecast routes (see screenshots below)

`Get All Available Forecasts`
![Screenshot 2023-06-28 at 11 00 42](https://github.com/openclimatefix/uk-pv-national-gsp-api/assets/86949265/90cea6cd-50bb-4b21-b718-0c4652a91bc3)

`Get Forecasts For a Specific GSP`

![Screenshot 2023-06-28 at 11 01 24](https://github.com/openclimatefix/uk-pv-national-gsp-api/assets/86949265/2b64db4e-1204-4a34-b262-d08ff9e04cce)

`Get Truths for All GSPs`
![Screenshot 2023-06-28 at 11 02 44](https://github.com/openclimatefix/uk-pv-national-gsp-api/assets/86949265/1ec9c479-13cc-46ba-99c9-1ff4cb425082)

`Get Truths for a Specific GSP`
![Screenshot 2023-06-28 at 11 02 59](https://github.com/openclimatefix/uk-pv-national-gsp-api/assets/86949265/2ec68ced-eb8b-411f-a64f-5b23dce3e134)

`Get GSP Boundaries `

<img width="616" alt="Screenshot 2023-06-27 at 15 02 22" src="https://github.com/openclimatefix/uk-pv-national-gsp-api/assets/86949265/c2e292d6-5cb2-412d-bbdf-deb4198dd247">

`Get System Details`

<img width="616" alt="Screenshot 2023-06-27 at 15 04 37" src="https://github.com/openclimatefix/uk-pv-national-gsp-api/assets/86949265/eec3649c-4242-4d53-8d1c-f0862e4ee238">


Fixes #222

## How Has This Been Tested?

Tests were run with Docker and the documentation was checked by running the code locally. 

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
