### PR TITLE
change nowcasting to quartz solar in get api info route

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -212,9 +212,9 @@ app.include_router(system_router, prefix=f"{v0_route_system}/gsp")
 
 @app.get("/")
 def get_api_information():
-    """### Get basic information about the Nowcasting API
+    """### Get basic Quartz Solar API information
 
-    The object returned contains basic information about the Nowcasting API.
+    Returns a json object with basic information about the Quartz Solar API.
 
     """
 
@@ -225,6 +225,7 @@ def get_api_information():
         "version": version,
         "description": description,
         "documentation": "https://api.quartz.solar/docs",
+        "swagger ui": "https://api.quartz.solar/swagger",
     }
 
 


### PR DESCRIPTION
# Pull Request

## Description

Remove Nowcasting from `Get API information`


## How Has This Been Tested?

Tested by running the code locally. 

- [x] Yes


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
