### PR TITLE
add weights that mix cnn pvnet_v2 and National_xg

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -50,13 +50,13 @@ weights = [
     {
         # cnn to pvnet_v2
         "start_horizon_hour": 1,
-        "end_horizon_hour": 3,
+        "end_horizon_hour": 2,
         "start_weight": [1, 0, 0],
         "end_weight": [0, 0, 1],
     },
     {
         # pvnet_v2
-        "start_horizon_hour": 3,
+        "start_horizon_hour": 2,
         "end_horizon_hour": 7,
         "start_weight": [0, 0, 1],
         "end_weight": [0, 0, 1],

--- a/src/database.py
+++ b/src/database.py
@@ -37,6 +37,44 @@ from utils import floor_30_minutes_dt, get_start_datetime
 
 logger = structlog.stdlib.get_logger()
 
+# merged from
+# - cnn
+# - pvnet_v2
+# - National_xg
+weights = [
+    {
+        # cnn
+        "end_horizon_hour": 1,
+        "end_weight": [1, 0, 0],
+    },
+    {
+        # cnn to pvnet_v2
+        "start_horizon_hour": 1,
+        "end_horizon_hour": 3,
+        "start_weight": [1, 0, 0],
+        "end_weight": [0, 0, 1],
+    },
+    {
+        # pvnet_v2
+        "start_horizon_hour": 3,
+        "end_horizon_hour": 7,
+        "start_weight": [0, 0, 1],
+        "end_weight": [0, 0, 1],
+    },
+    {
+        # pvnet_v2 to National_xg
+        "start_horizon_hour": 7,
+        "end_horizon_hour": 8,
+        "start_weight": [0, 0, 1],
+        "end_weight": [0, 1, 0],
+    },
+    {
+        # National_xg
+        "start_horizon_hour": 8,
+        "start_weight": [0, 1, 0],
+    },
+]
+
 
 def get_latest_status_from_database(session: Session) -> Status:
     """Get latest status from database"""
@@ -142,6 +180,8 @@ def get_latest_forecast_values_for_a_specific_gsp_from_database(
                 gsp_id=0,
                 start_datetime=start_datetime,
                 properties_model="National_xg",
+                weights=weights,
+                model_names=["cnn", "National_xg", "pvnet_v2"]
             )
 
     else:
@@ -150,6 +190,8 @@ def get_latest_forecast_values_for_a_specific_gsp_from_database(
             gsp_id=gsp_id,
             start_datetime=start_datetime,
             forecast_horizon_minutes=forecast_horizon_minutes,
+            weights=weights,
+            model_names=["cnn", "National_xg", "pvnet_v2"]
         )
 
     # convert to pydantic objects

--- a/src/national.py
+++ b/src/national.py
@@ -81,10 +81,10 @@ def get_national_forecast(
     forecast_values = [f.adjust(limit=adjust_limit) for f in forecast_values]
 
     if not get_plevels:
-        logger.debug('Not getting plevels')
+        logger.debug("Not getting plevels")
         national_forecast_values = [NationalForecastValue(**f.__dict__) for f in forecast_values]
     else:
-        logger.debug('Getting plevels')
+        logger.debug("Getting plevels")
         # change to NationalForecastValue
         national_forecast_values = []
         for f in forecast_values:

--- a/src/national.py
+++ b/src/national.py
@@ -21,7 +21,7 @@ logger = structlog.stdlib.get_logger()
 
 
 adjust_limit = float(os.getenv("ADJUST_MW_LIMIT", 0.0))
-default_plevels = bool(os.getenv("DEFAULT_PLEVELS", True))
+get_plevels = bool(os.getenv("GET_PLEVELS", True))
 
 router = APIRouter()
 
@@ -80,38 +80,40 @@ def get_national_forecast(
 
     forecast_values = [f.adjust(limit=adjust_limit) for f in forecast_values]
 
-    # change to NationalForecastValue
-    national_forecast_values = []
-    for f in forecast_values:
+    if not get_plevels:
+        logger.debug('Not getting plevels')
+        national_forecast_values = [NationalForecastValue(**f.__dict__) for f in forecast_values]
+    else:
+        logger.debug('Getting plevels')
         # change to NationalForecastValue
-        plevels = f._properties
-        national_forecast_value = NationalForecastValue(**f.__dict__)
-        national_forecast_value.plevels = plevels
+        national_forecast_values = []
+        for f in forecast_values:
+            # change to NationalForecastValue
+            plevels = f._properties
+            national_forecast_value = NationalForecastValue(**f.__dict__)
+            national_forecast_value.plevels = plevels
 
-        # add default values in, we will remove this at some point
-        if (not isinstance(national_forecast_value.plevels, dict)) or (
-            national_forecast_value.plevels == {}
-        ):
-            logger.warning(
-                f"Using default properties for {national_forecast_value.__fields__.keys()}"
-            )
-            if default_plevels:
+            # add default values in, we will remove this at some point
+            if (not isinstance(national_forecast_value.plevels, dict)) or (
+                national_forecast_value.plevels == {}
+            ):
+                logger.warning(
+                    f"Using default properties for {national_forecast_value.__fields__.keys()}"
+                )
                 national_forecast_value.plevels = {
                     "plevel_10": national_forecast_value.expected_power_generation_megawatts * 0.8,
                     "plevel_90": national_forecast_value.expected_power_generation_megawatts * 1.2,
                 }
-            else:
-                national_forecast_value.plevels = {}
-            logger.debug(f"{national_forecast_value.plevels}")
+                logger.debug(f"{national_forecast_value.plevels}")
 
-        # rename '10' and '90' to plevel_10 and plevel_90
-        for c in ["10", "90"]:
-            if c in national_forecast_value.plevels.keys():
-                national_forecast_value.plevels[
-                    f"plevel_{c}"
-                ] = national_forecast_value.plevels.pop(c)
+            # rename '10' and '90' to plevel_10 and plevel_90
+            for c in ["10", "90"]:
+                if c in national_forecast_value.plevels.keys():
+                    national_forecast_value.plevels[
+                        f"plevel_{c}"
+                    ] = national_forecast_value.plevels.pop(c)
 
-        national_forecast_values.append(national_forecast_value)
+            national_forecast_values.append(national_forecast_value)
 
     return national_forecast_values
 

--- a/src/national.py
+++ b/src/national.py
@@ -21,6 +21,7 @@ logger = structlog.stdlib.get_logger()
 
 
 adjust_limit = float(os.getenv("ADJUST_MW_LIMIT", 0.0))
+default_plevels = bool(os.getenv("DEFAULT_PLEVELS", True))
 
 router = APIRouter()
 
@@ -94,10 +95,13 @@ def get_national_forecast(
             logger.warning(
                 f"Using default properties for {national_forecast_value.__fields__.keys()}"
             )
-            national_forecast_value.plevels = {
-                "plevel_10": national_forecast_value.expected_power_generation_megawatts * 0.8,
-                "plevel_90": national_forecast_value.expected_power_generation_megawatts * 1.2,
-            }
+            if default_plevels:
+                national_forecast_value.plevels = {
+                    "plevel_10": national_forecast_value.expected_power_generation_megawatts * 0.8,
+                    "plevel_90": national_forecast_value.expected_power_generation_megawatts * 1.2,
+                }
+            else:
+                national_forecast_value.plevels = {}
             logger.debug(f"{national_forecast_value.plevels}")
 
         # rename '10' and '90' to plevel_10 and plevel_90


### PR DESCRIPTION
# Pull Request

## Description

Add pvnet into blend. The blend is
`cnn` -> `pvnet_v2` -> `National_xg`

1. Hour 1 is `CNN`
2. Hour 1  to 2 is linear blend from `CNN` to `Pvnet_V2`
3. Hour 2 to 7 is `PVnet`
4. Hour 7 to 8 is linear blend from `PVnet_v2` to `National_xg`
5. Hour 8 outwards is `National_xg`

added a enviornment variable to turn off default probabilistic levels

Evidence from https://github.com/openclimatefix/PVNet/issues/30

## How Has This Been Tested?

- CI tests
- run locally

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
