### PR TITLE
Add start datetime parameter to gsp/pvlive endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ psycopg2-binary
 geopandas
 aiofiles
 pytest-cov
+testcontainers
 fastapi-auth0==0.3.0
 httpx
 structlog

--- a/src/database.py
+++ b/src/database.py
@@ -233,8 +233,10 @@ def get_latest_national_forecast_from_database(session: Session) -> Forecast:
 
 
 def get_truth_values_for_a_specific_gsp_from_database(
-    session: Session, gsp_id: int, regime: Optional[str] = "in-day",
-        start_datetime: Optional[datetime] = None
+    session: Session,
+    gsp_id: int,
+    regime: Optional[str] = "in-day",
+    start_datetime: Optional[datetime] = None,
 ) -> List[GSPYield]:
     """Get the truth value for one gsp for yesterday and today
 

--- a/src/database.py
+++ b/src/database.py
@@ -243,11 +243,14 @@ def get_truth_values_for_a_specific_gsp_from_database(
     :param gsp_id: gsp id
     :param regime: option for "in-day" or "day-after"
     :param start_datetime: optional start datetime for the query.
-    If not set, defaults to N_HISTORY_DAYS env var, which defaults to yesterday.
+     If not set, after now, or set to over three days ago
+     defaults to N_HISTORY_DAYS env var, which defaults to yesterday.
     :return: list of gsp yields
     """
 
-    if start_datetime is None:
+    if start_datetime is None \
+       or start_datetime >= datetime.now(tz=timezone.utc) \
+       or datetime.now(tz=timezone.utc) - start_datetime > timedelta(days=3):
         start_datetime = get_start_datetime()
 
     return get_gsp_yield(

--- a/src/database.py
+++ b/src/database.py
@@ -1,6 +1,7 @@
 """ Functions to read from the database and format """
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
+from pytz import timezone
 from typing import List, Optional
 
 import structlog
@@ -232,22 +233,26 @@ def get_latest_national_forecast_from_database(session: Session) -> Forecast:
 
 
 def get_truth_values_for_a_specific_gsp_from_database(
-    session: Session, gsp_id: int, regime: Optional[str] = "in-day"
+    session: Session, gsp_id: int, regime: Optional[str] = "in-day",
+        start_datetime: Optional[datetime] = None
 ) -> List[GSPYield]:
     """Get the truth value for one gsp for yesterday and today
 
     :param session: sql session
     :param gsp_id: gsp id
     :param regime: option for "in-day" or "day-after"
+    :param start_datetime: optional start datetime for the query.
+    If not set, defaults to N_HISTORY_DAYS env var, which defaults to yesterday.
     :return: list of gsp yields
     """
 
-    start_datetime = get_start_datetime()
+    if start_datetime is None:
+        start_datetime = get_start_datetime()
 
     return get_gsp_yield(
         session=session,
         gsp_ids=[gsp_id],
-        start_datetime_utc=start_datetime,
+        start_datetime_utc=timezone("Europe/London").localize(start_datetime),
         regime=regime,
     )
 

--- a/src/database.py
+++ b/src/database.py
@@ -248,9 +248,11 @@ def get_truth_values_for_a_specific_gsp_from_database(
     :return: list of gsp yields
     """
 
-    if start_datetime is None \
-       or start_datetime >= datetime.now(tz=timezone.utc) \
-       or datetime.now(tz=timezone.utc) - start_datetime > timedelta(days=3):
+    if (
+        start_datetime is None
+        or start_datetime >= datetime.now(tz=timezone.utc)
+        or datetime.now(tz=timezone.utc) - start_datetime > timedelta(days=3)
+    ):
         start_datetime = get_start_datetime()
 
     return get_gsp_yield(

--- a/src/database.py
+++ b/src/database.py
@@ -1,7 +1,6 @@
 """ Functions to read from the database and format """
 import os
-from datetime import datetime, timedelta
-from pytz import timezone
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 import structlog
@@ -254,7 +253,7 @@ def get_truth_values_for_a_specific_gsp_from_database(
     return get_gsp_yield(
         session=session,
         gsp_ids=[gsp_id],
-        start_datetime_utc=timezone("Europe/London").localize(start_datetime),
+        start_datetime_utc=start_datetime,
         regime=regime,
     )
 

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -1,4 +1,5 @@
 """Get GSP boundary data from eso """
+from datetime import datetime
 from typing import List, Optional, Union
 
 import structlog
@@ -212,6 +213,7 @@ def get_truths_for_a_specific_gsp(
     request: Request,
     gsp_id: int,
     regime: Optional[str] = None,
+    start_datetime_utc: Optional[datetime] = None,
     session: Session = Depends(get_session),
     user: Auth0User = Security(get_user()),
 ) -> List[GSPYield]:
@@ -228,6 +230,8 @@ def get_truths_for_a_specific_gsp(
     #### Parameters
     - **gsp_id**: _gsp_id_ of the requested forecast
     - **regime**: can choose __in-day__ or __day-after__
+    - **start_datetime_utc**: optional start datetime for the query.
+    If not set, defaults to N_HISTORY_DAYS env var, which if not set defaults to yesterday.
     """
 
     logger.info(
@@ -238,5 +242,5 @@ def get_truths_for_a_specific_gsp(
         return Response(None, status.HTTP_204_NO_CONTENT)
 
     return get_truth_values_for_a_specific_gsp_from_database(
-        session=session, gsp_id=gsp_id, regime=regime
+        session=session, gsp_id=gsp_id, regime=regime, start_datetime=start_datetime
     )

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -242,5 +242,5 @@ def get_truths_for_a_specific_gsp(
         return Response(None, status.HTTP_204_NO_CONTENT)
 
     return get_truth_values_for_a_specific_gsp_from_database(
-        session=session, gsp_id=gsp_id, regime=regime, start_datetime=start_datetime
+        session=session, gsp_id=gsp_id, regime=regime, start_datetime=start_datetime_utc
     )

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,13 +1,11 @@
 """ Pytest fixitures for tests """
 import os
-import tempfile
 
 import pytest
 from fastapi.testclient import TestClient
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.fake import make_fake_forecasts
 from nowcasting_datamodel.models.base import Base_PV
-from testcontainers.postgres import PostgresContainer
 
 from auth_utils import get_auth_implicit_scheme, get_user
 from database import get_session

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -28,15 +28,26 @@ def forecasts(db_session):
 def db_connection():
     """Pytest fixture for a database connection"""
 
-    with PostgresContainer("postgres:14.5") as postgres:
-        connection = DatabaseConnection(url=postgres.get_connection_url())
-        connection.create_all()
-        Base_PV.metadata.create_all(connection.engine)
+    # -- Uncomment for dockerised testing --
+    # with PostgresContainer("postgres:14.5") as postgres:
+    #    connection = DatabaseConnection(url=postgres.get_connection_url())
+    #    connection.create_all()
+    #    Base_PV.metadata.create_all(connection.engine)
+    #
+    #    yield connection
+    #
+    #    connection.drop_all()
+    #    Base_PV.metadata.drop_all(connection.engine)
 
-        yield connection
+    url = os.environ["DB_URL"]
+    connection = DatabaseConnection(url=url)
+    connection.create_all()
+    Base_PV.metadata.create_all(connection.engine)
 
-        connection.drop_all()
-        Base_PV.metadata.drop_all(connection.engine)
+    yield connection
+
+    connection.drop_all()
+    Base_PV.metadata.drop_all(connection.engine)
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,11 +1,13 @@
 """ Pytest fixitures for tests """
 import os
+import tempfile
 
 import pytest
 from fastapi.testclient import TestClient
 from nowcasting_datamodel.connection import DatabaseConnection
 from nowcasting_datamodel.fake import make_fake_forecasts
 from nowcasting_datamodel.models.base import Base_PV
+from testcontainers.postgres import PostgresContainer
 
 from auth_utils import get_auth_implicit_scheme, get_user
 from database import get_session
@@ -25,21 +27,16 @@ def forecasts(db_session):
 @pytest.fixture
 def db_connection():
     """Pytest fixture for a database connection"""
-    # with tempfile.NamedTemporaryFile(suffix="db") as tmp:
-    #     set url option to not check same thread, this solves an error seen in testing
 
-    # url = f"sqlite:///{tmp.name}.db?check_same_thread=False"
-    # os.environ["DB_URL"] = url
-    # os.environ["DB_URL_PV"] = url
-    url = os.environ["DB_URL"]
-    connection = DatabaseConnection(url=url)
-    connection.create_all()
-    Base_PV.metadata.create_all(connection.engine)
+    with PostgresContainer("postgres:14.5") as postgres:
+        connection = DatabaseConnection(url=postgres.get_connection_url())
+        connection.create_all()
+        Base_PV.metadata.create_all(connection.engine)
 
-    yield connection
+        yield connection
 
-    connection.drop_all()
-    Base_PV.metadata.drop_all(connection.engine)
+        connection.drop_all()
+        Base_PV.metadata.drop_all(connection.engine)
 
 
 @pytest.fixture(scope="function", autouse=True)


### PR DESCRIPTION
# Adds the start_datetime_utc parameter to gsp/pvlive to enable specification of a start datetime