### PR TITLE
Remove pin on opencv-contrib-python-headless==4.5.5.64

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv-contrib-python-headless==4.5.5.64
+opencv-contrib-python-headless
 fastapi
 uvicorn[standard]
 pydantic


### PR DESCRIPTION
Remove version pin for opencv-contrib-python-headless

This commit removes the specific version pin (4.5.5.64) for opencv-contrib-python-headless in the dependencies. Removing the version pin allows the project to use the latest available version of opencv-contrib-python-headless during installation.

Due, that I'm not part of the organization, the test could fall so please ensure to thoroughly test the project's functionality with the updated dependency configuration