### PR TITLE
remove blending, and just load blend

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -22,6 +22,7 @@ from nowcasting_datamodel.read.blend.blend import get_blend_forecast_values_late
 from nowcasting_datamodel.read.read import (
     get_all_gsp_ids_latest_forecast,
     get_all_locations,
+    get_forecast_values,
     get_forecast_values_latest,
     get_latest_forecast,
     get_latest_national_forecast,
@@ -176,13 +177,12 @@ def get_latest_forecast_values_for_a_specific_gsp_from_database(
         )
 
     else:
-        forecast_values = get_blend_forecast_values_latest(
+        forecast_values = get_forecast_values(
             session=session,
             gsp_id=gsp_id,
             start_datetime=start_datetime,
             forecast_horizon_minutes=forecast_horizon_minutes,
-            weights=weights,
-            model_names=["cnn", "National_xg", "pvnet_v2"],
+            model_name="blend",
         )
 
     # convert to pydantic objects

--- a/src/database.py
+++ b/src/database.py
@@ -183,6 +183,8 @@ def get_latest_forecast_values_for_a_specific_gsp_from_database(
             start_datetime=start_datetime,
             forecast_horizon_minutes=forecast_horizon_minutes,
             model_name="blend",
+            model=ForecastValueSevenDaysSQL,
+            only_return_latest=True,
         )
 
     # convert to pydantic objects


### PR DESCRIPTION
# Pull Request

## Description

Remove blend from API for loading 4 hour view.
Need blend service > 0.0.12
This speeds up api for 4 hour view from 7 seconds to 3 seconds (locally)

Helps with #61 

## How Has This Been Tested?

- CI tests
- run it locally

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
