### PR TITLE
add option to return metadata in national forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,12 @@ Deployment of this service is now done through terraform cloud.
 ```mermaid
   graph TD;
       N1(national/forecast) --> Q1;
+      Q1{Include metadata?>} -->|no| Q2;
+      Q1 --> |yes| N2[NationalForecast];
       N4[ForecastValueLatest];
-      Q1{forecast horizon <br> minutes not None}
-      Q1-->|yes| N5[ForecastValueSevenDays];
-      Q1-->|no| N4;
+      Q2{forecast horizon <br> minutes not None}
+      Q2-->|yes| N5[ForecastValueSevenDays];
+      Q2-->|no| N4;
 
       NP1(national/pvlive)-->NP2;
       NP2[GSPYield];

--- a/src/national.py
+++ b/src/national.py
@@ -15,7 +15,7 @@ from database import (
     get_session,
     get_truth_values_for_a_specific_gsp_from_database,
 )
-from pydantic_models import NationalForecast, NationalYield, NationalForecastValue
+from pydantic_models import NationalForecast, NationalForecastValue, NationalYield
 from utils import format_plevels
 
 logger = structlog.stdlib.get_logger()

--- a/src/national.py
+++ b/src/national.py
@@ -3,9 +3,9 @@ import os
 from typing import List, Optional, Union
 
 import structlog
-from fastapi import APIRouter, Depends, Request, Security
+from fastapi import APIRouter, Depends, Request, Security, HTTPException
 from fastapi_auth0 import Auth0User
-from nowcasting_datamodel.models import Forecast, GSPYield
+from nowcasting_datamodel.models import Forecast
 from sqlalchemy.orm.session import Session
 
 from auth_utils import get_auth_implicit_scheme, get_user
@@ -15,7 +15,9 @@ from database import (
     get_session,
     get_truth_values_for_a_specific_gsp_from_database,
 )
-from utils import NationalForecastValue, format_plevels
+from nowcasting_datamodel.read.read import get_latest_forecast_for_gsps
+from pydantic_models import NationalYield, NationalForecast, NationalForecastValue
+from utils import format_plevels
 
 logger = structlog.stdlib.get_logger()
 
@@ -25,12 +27,10 @@ get_plevels = bool(os.getenv("GET_PLEVELS", True))
 
 router = APIRouter()
 
-NationalYield = GSPYield
-
 
 @router.get(
     "/forecast",
-    response_model=Union[Forecast, List[NationalForecastValue]],
+    response_model=Union[NationalForecast, List[NationalForecastValue]],
     dependencies=[Depends(get_auth_implicit_scheme())],
 )
 @cache_response
@@ -39,7 +39,8 @@ def get_national_forecast(
     session: Session = Depends(get_session),
     forecast_horizon_minutes: Optional[int] = None,
     user: Auth0User = Security(get_user()),
-) -> Union[Forecast, List[NationalForecastValue]]:
+    include_metadata: bool = False,
+) -> Union[NationalForecast, List[NationalForecastValue]]:
     """Get the National Forecast
 
     This route returns the most recent forecast for each _target_time_.
@@ -60,9 +61,25 @@ def get_national_forecast(
     logger.debug("Get national forecasts")
 
     logger.debug("Getting forecast.")
-    forecast_values = get_latest_forecast_values_for_a_specific_gsp_from_database(
-        session=session, gsp_id=0, forecast_horizon_minutes=forecast_horizon_minutes
-    )
+    if include_metadata:
+
+        if forecast_horizon_minutes is not None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Can not set forecast_horizon_minutes" f" when including metadata",
+            )
+
+        forecast = get_latest_forecast_for_gsps(
+            session=session, gsp_ids=[0], model_name="blend", historic=True, preload_children=True
+        )
+        forecast = forecast[0]
+
+        forecast = NationalForecast.from_orm_latest(forecast)
+        forecast_values = forecast.forecast_values
+    else:
+        forecast_values = get_latest_forecast_values_for_a_specific_gsp_from_database(
+            session=session, gsp_id=0, forecast_horizon_minutes=forecast_horizon_minutes
+        )
 
     logger.debug(
         f"Got national forecasts with {len(forecast_values)} forecast values. "
@@ -88,8 +105,12 @@ def get_national_forecast(
             format_plevels(national_forecast_value)
 
             national_forecast_values.append(national_forecast_value)
-
-    return national_forecast_values
+    if include_metadata:
+        # return full forecast object
+        forecast.forecast_values = national_forecast_values
+        return forecast
+    else:
+        return national_forecast_values
 
 
 # corresponds to API route /v0/solar/GB/national/pvlive/, getting PV_Live NationalYield for GB

--- a/src/national.py
+++ b/src/national.py
@@ -15,7 +15,7 @@ from database import (
     get_session,
     get_truth_values_for_a_specific_gsp_from_database,
 )
-from pydantic_models import NationalYield, NationalForecast, NationalForecastValue
+from pydantic_models import NationalForecast, NationalYield, NationalForecastValue
 from utils import format_plevels
 
 logger = structlog.stdlib.get_logger()

--- a/src/national.py
+++ b/src/national.py
@@ -3,9 +3,9 @@ import os
 from typing import List, Optional, Union
 
 import structlog
-from fastapi import APIRouter, Depends, Request, Security, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request, Security
 from fastapi_auth0 import Auth0User
-from nowcasting_datamodel.models import Forecast
+from nowcasting_datamodel.read.read import get_latest_forecast_for_gsps
 from sqlalchemy.orm.session import Session
 
 from auth_utils import get_auth_implicit_scheme, get_user
@@ -15,7 +15,6 @@ from database import (
     get_session,
     get_truth_values_for_a_specific_gsp_from_database,
 )
-from nowcasting_datamodel.read.read import get_latest_forecast_for_gsps
 from pydantic_models import NationalYield, NationalForecast, NationalForecastValue
 from utils import format_plevels
 
@@ -65,7 +64,7 @@ def get_national_forecast(
         if forecast_horizon_minutes is not None:
             raise HTTPException(
                 status_code=404,
-                detail=f"Can not set forecast_horizon_minutes" f" when including metadata",
+                detail="Can not set forecast_horizon_minutes when including metadata",
             )
 
         forecast = get_latest_forecast_for_gsps(

--- a/src/pydantic_models.py
+++ b/src/pydantic_models.py
@@ -3,7 +3,14 @@ import logging
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from nowcasting_datamodel.models import ForecastSQL, Location, LocationSQL
+from nowcasting_datamodel.models import (
+    Forecast,
+    ForecastSQL,
+    Location,
+    LocationSQL,
+    GSPYield,
+    ForecastValue,
+)
 from nowcasting_datamodel.models.utils import EnhancedBaseModel
 from pydantic import Field
 
@@ -159,3 +166,20 @@ def convert_forecasts_to_many_datetime_many_generation(
         )
 
     return many_forecast_values
+
+
+NationalYield = GSPYield
+
+
+class NationalForecastValue(ForecastValue):
+    """One Forecast of generation at one timestamp include properties"""
+
+    plevels: dict = Field(
+        None, description="Dictionary to hold properties of the forecast, like p_levels. "
+    )
+
+
+class NationalForecast(Forecast):
+    """One Forecast of generation at one timestamp"""
+
+    forecast_values: List[NationalForecastValue] = Field(..., description="List of forecast values")

--- a/src/pydantic_models.py
+++ b/src/pydantic_models.py
@@ -3,13 +3,7 @@ import logging
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from nowcasting_datamodel.models import (
-    Forecast,
-    ForecastSQL,
-    ForecastValue,
-    Location,
-    LocationSQL,
-)
+from nowcasting_datamodel.models import Forecast, ForecastSQL, ForecastValue, Location, LocationSQL
 from nowcasting_datamodel.models.utils import EnhancedBaseModel
 from pydantic import Field
 

--- a/src/pydantic_models.py
+++ b/src/pydantic_models.py
@@ -6,10 +6,9 @@ from typing import Dict, List, Optional
 from nowcasting_datamodel.models import (
     Forecast,
     ForecastSQL,
+    ForecastValue,
     Location,
     LocationSQL,
-    GSPYield,
-    ForecastValue,
 )
 from nowcasting_datamodel.models.utils import EnhancedBaseModel
 from pydantic import Field

--- a/src/tests/test_national.py
+++ b/src/tests/test_national.py
@@ -10,7 +10,7 @@ from nowcasting_datamodel.save.update import update_all_forecast_latest
 
 from database import get_session
 from main import app
-from utils import NationalForecastValue
+from pydantic_models import NationalForecast, NationalForecastValue
 
 
 def test_read_latest_national_values(db_session, api_client):
@@ -40,6 +40,56 @@ def test_read_latest_national_values(db_session, api_client):
         national_forecast_values[24].plevels["plevel_10"]
         != national_forecast_values[0].expected_power_generation_megawatts * 0.9
     )
+
+
+def test_get_national_forecast(db_session, api_client):
+    """Check main solar/GB/national/forecast route works"""
+
+    model = get_model(db_session, name="blend", version="0.0.1")
+
+    forecast = make_fake_national_forecast(
+        session=db_session, t0_datetime_utc=datetime.now(tz=timezone.utc)
+    )
+    forecast.model = model
+
+    assert forecast.forecast_values[0].properties is not None
+
+    db_session.add(forecast)
+    update_all_forecast_latest(forecasts=[forecast], session=db_session)
+
+    app.dependency_overrides[get_session] = lambda: db_session
+
+    response = api_client.get("/v0/solar/GB/national/forecast?include_metadata=true")
+    assert response.status_code == 200
+
+    national_forecast = NationalForecast(**response.json())
+    assert national_forecast.forecast_values[0].plevels is not None
+    # index 24 is the middle of the day
+    assert (
+        national_forecast.forecast_values[24].plevels["plevel_10"]
+        != national_forecast.forecast_values[0].expected_power_generation_megawatts * 0.9
+    )
+
+
+def test_get_national_forecast_error(db_session, api_client):
+    """Check main solar/GB/national/forecast route works"""
+
+    model = get_model(db_session, name="blend", version="0.0.1")
+
+    forecast = make_fake_national_forecast(
+        session=db_session, t0_datetime_utc=datetime.now(tz=timezone.utc)
+    )
+    forecast.model = model
+
+    assert forecast.forecast_values[0].properties is not None
+
+    db_session.add(forecast)
+    update_all_forecast_latest(forecasts=[forecast], session=db_session)
+
+    app.dependency_overrides[get_session] = lambda: db_session
+
+    response = api_client.get("/v0/solar/GB/national/forecast?include_metadata=true&forecast_horizon_minutes=60")
+    assert response.status_code == 404
 
 
 def test_read_latest_national_values_no_properties(db_session, api_client):

--- a/src/tests/test_national.py
+++ b/src/tests/test_national.py
@@ -88,7 +88,9 @@ def test_get_national_forecast_error(db_session, api_client):
 
     app.dependency_overrides[get_session] = lambda: db_session
 
-    response = api_client.get("/v0/solar/GB/national/forecast?include_metadata=true&forecast_horizon_minutes=60")
+    response = api_client.get(
+        "/v0/solar/GB/national/forecast?include_metadata=true&forecast_horizon_minutes=60"
+    )
     assert response.status_code == 404
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -5,22 +5,15 @@ from typing import List, Optional, Union
 
 import numpy as np
 import structlog
-from nowcasting_datamodel.models import Forecast, ForecastValue
-from pydantic import Field
+from nowcasting_datamodel.models import Forecast
 from pytz import timezone
+
+from pydantic_models import NationalForecastValue
 
 logger = structlog.stdlib.get_logger()
 
 europe_london_tz = timezone("Europe/London")
 utc = timezone("UTC")
-
-
-class NationalForecastValue(ForecastValue):
-    """One Forecast of generation at one timestamp include properties"""
-
-    plevels: dict = Field(
-        None, description="Dictionary to hold properties of the forecast, like p_levels. "
-    )
 
 
 def floor_30_minutes_dt(dt):


### PR DESCRIPTION
# Pull Request

## Description

add option to return metadata in national forecast
added test
udpated readme

Fixes #261 

## How Has This Been Tested?

CI tests + ran locally

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
