### PR TITLE
add creation filter on gsp forecast route

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -195,6 +195,7 @@ def get_latest_forecast_values_for_a_specific_gsp_from_database(
     forecast_horizon_minutes: Optional[int] = None,
     start_datetime_utc: Optional[datetime] = None,
     end_datetime_utc: Optional[datetime] = None,
+    creation_utc_limit: Optional[datetime] = None,
 ) -> List[ForecastValue]:
     """Get the forecast values for yesterday and today for one gsp
 
@@ -207,7 +208,7 @@ def get_latest_forecast_values_for_a_specific_gsp_from_database(
 
     start_datetime = get_start_datetime(start_datetime=start_datetime_utc)
 
-    if forecast_horizon_minutes is None:
+    if (forecast_horizon_minutes is None) and (creation_utc_limit is None):
         forecast_values = get_forecast_values_latest(
             session=session,
             gsp_id=gsp_id,
@@ -225,6 +226,7 @@ def get_latest_forecast_values_for_a_specific_gsp_from_database(
             model_name="blend",
             model=ForecastValueSevenDaysSQL,
             only_return_latest=True,
+            created_utc_limit=creation_utc_limit,
         )
 
     # convert to pydantic objects

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -141,6 +141,7 @@ def get_forecasts_for_a_specific_gsp(
     user: Auth0User = Security(get_user()),
     start_datetime_utc: Optional[str] = None,
     end_datetime_utc: Optional[str] = None,
+    creation_limit_utc: Optional[str] = None,
 ) -> Union[Forecast, List[ForecastValue]]:
     """### Get recent forecast values for a specific GSP
 
@@ -160,6 +161,7 @@ def get_forecasts_for_a_specific_gsp(
     - **forecast_horizon_minutes**: optional forecast horizon in minutes (ex. 60
     - **start_datetime_utc**: optional start datetime for the query.
     - **end_datetime_utc**: optional end datetime for the query.
+    - **creation_utc_limit**: optional, only return forecasts made before this datetime.
     returns the latest forecast made 60 minutes before the target time)
     """
 
@@ -178,6 +180,7 @@ def get_forecasts_for_a_specific_gsp(
         forecast_horizon_minutes=forecast_horizon_minutes,
         start_datetime_utc=start_datetime_utc,
         end_datetime_utc=end_datetime_utc,
+        creation_utc_limit=creation_limit_utc,
     )
 
     logger.debug("Got forecast values for a specific gsp.")


### PR DESCRIPTION
# Pull Request

## Description

Add creation filter on `gsp/{gsp_id}/forecast`
Fixes #290 

## How Has This Been Tested?

CI tests
added tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
