### PR TITLE
add rate limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ fastapi-auth0==0.3.0
 httpx
 structlog
 sentry-sdk
+slowapi

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -24,7 +24,7 @@ from pydantic_models import (
     LocationWithGSPYields,
     OneDatetimeManyForecastValues,
 )
-from utils import format_datetime, limiter, N_CALLS_PER_HOUR
+from utils import N_CALLS_PER_HOUR, format_datetime, limiter
 
 GSP_TOTAL = 317
 

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -24,7 +24,7 @@ from pydantic_models import (
     LocationWithGSPYields,
     OneDatetimeManyForecastValues,
 )
-from utils import format_datetime
+from utils import format_datetime, limiter, N_CALLS_PER_HOUR
 
 GSP_TOTAL = 317
 
@@ -44,6 +44,7 @@ NationalYield = GSPYield
     dependencies=[Depends(get_auth_implicit_scheme())],
 )
 @cache_response
+@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def get_all_available_forecasts(
     request: Request,
     historic: Optional[bool] = True,
@@ -111,6 +112,7 @@ def get_all_available_forecasts(
     responses={status.HTTP_204_NO_CONTENT: {"model": None}},
 )
 @cache_response
+@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def get_forecasts_for_a_specific_gsp_old_route(
     request: Request,
     gsp_id: int,
@@ -135,6 +137,7 @@ def get_forecasts_for_a_specific_gsp_old_route(
     responses={status.HTTP_204_NO_CONTENT: {"model": None}},
 )
 @cache_response
+@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def get_forecasts_for_a_specific_gsp(
     request: Request,
     gsp_id: int,
@@ -203,6 +206,7 @@ def get_forecasts_for_a_specific_gsp(
     dependencies=[Depends(get_auth_implicit_scheme())],
 )
 @cache_response
+@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def get_truths_for_all_gsps(
     request: Request,
     regime: Optional[str] = None,
@@ -257,6 +261,7 @@ def get_truths_for_all_gsps(
     responses={status.HTTP_204_NO_CONTENT: {"model": None}},
 )
 @cache_response
+@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def get_truths_for_a_specific_gsp_old_route(
     request: Request,
     gsp_id: int,
@@ -282,6 +287,7 @@ def get_truths_for_a_specific_gsp_old_route(
     responses={status.HTTP_204_NO_CONTENT: {"model": None}},
 )
 @cache_response
+@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def get_truths_for_a_specific_gsp(
     request: Request,
     gsp_id: int,

--- a/src/main.py
+++ b/src/main.py
@@ -9,13 +9,15 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import FileResponse
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
 
 from gsp import router as gsp_router
 from national import router as national_router
 from redoc_theme import get_redoc_html_with_theme
 from status import router as status_router
 from system import router as system_router
-from utils import traces_sampler
+from utils import traces_sampler, limiter
 
 # flake8: noqa E501
 
@@ -182,6 +184,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 
 @app.middleware("http")

--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,7 @@ from national import router as national_router
 from redoc_theme import get_redoc_html_with_theme
 from status import router as status_router
 from system import router as system_router
-from utils import traces_sampler, limiter
+from utils import limiter, traces_sampler
 
 # flake8: noqa E501
 

--- a/src/national.py
+++ b/src/national.py
@@ -16,7 +16,7 @@ from database import (
     get_truth_values_for_a_specific_gsp_from_database,
 )
 from pydantic_models import NationalForecast, NationalForecastValue, NationalYield
-from utils import filter_forecast_values, format_datetime, format_plevels
+from utils import filter_forecast_values, format_datetime, format_plevels, limiter, N_CALLS_PER_HOUR
 
 logger = structlog.stdlib.get_logger()
 
@@ -33,6 +33,7 @@ router = APIRouter()
     dependencies=[Depends(get_auth_implicit_scheme())],
 )
 @cache_response
+@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def get_national_forecast(
     request: Request,
     session: Session = Depends(get_session),
@@ -156,6 +157,7 @@ def get_national_forecast(
     dependencies=[Depends(get_auth_implicit_scheme())],
 )
 @cache_response
+@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def get_national_pvlive(
     request: Request,
     regime: Optional[str] = None,

--- a/src/national.py
+++ b/src/national.py
@@ -16,7 +16,7 @@ from database import (
     get_truth_values_for_a_specific_gsp_from_database,
 )
 from pydantic_models import NationalForecast, NationalForecastValue, NationalYield
-from utils import filter_forecast_values, format_datetime, format_plevels, limiter, N_CALLS_PER_HOUR
+from utils import N_CALLS_PER_HOUR, filter_forecast_values, format_datetime, format_plevels, limiter
 
 logger = structlog.stdlib.get_logger()
 

--- a/src/status.py
+++ b/src/status.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm.session import Session
 
 from cache import cache_response
 from database import get_latest_status_from_database, get_session, save_api_call_to_db
-from utils import limiter, N_CALLS_PER_HOUR
+from utils import N_CALLS_PER_HOUR, limiter
 
 logger = structlog.stdlib.get_logger()
 

--- a/src/status.py
+++ b/src/status.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm.session import Session
 
 from cache import cache_response
 from database import get_latest_status_from_database, get_session, save_api_call_to_db
+from utils import limiter, N_CALLS_PER_HOUR
 
 logger = structlog.stdlib.get_logger()
 
@@ -20,6 +21,7 @@ forecast_error_hours = float(os.getenv("FORECAST_ERROR_HOURS", 2.0))
 
 @router.get("/status", response_model=Status)
 @cache_response
+@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def get_status(request: Request, session: Session = Depends(get_session)) -> Status:
     """### Get status for the database and forecasts
 
@@ -32,6 +34,7 @@ def get_status(request: Request, session: Session = Depends(get_session)) -> Sta
 
 
 @router.get("/check_last_forecast_run", include_in_schema=False)
+@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def check_last_forecast(request: Request, session: Session = Depends(get_session)) -> datetime:
     """Check to that a forecast has run with in the last 2 hours"""
 

--- a/src/system.py
+++ b/src/system.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm.session import Session
 from auth_utils import get_auth_implicit_scheme, get_user
 from cache import cache_response
 from database import get_gsp_system, get_session
+from utils import limiter, N_CALLS_PER_HOUR
 
 # flake8: noqa: E501
 logger = structlog.stdlib.get_logger()
@@ -43,6 +44,7 @@ def get_gsp_boundaries_from_eso_wgs84() -> gpd.GeoDataFrame:
     dependencies=[Depends(get_auth_implicit_scheme())],
 )
 @cache_response
+@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def get_gsp_boundaries(
     request: Request,
     session: Session = Depends(get_session),
@@ -75,6 +77,7 @@ def get_gsp_boundaries(
     dependencies=[Depends(get_auth_implicit_scheme())],
 )
 @cache_response
+@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def get_system_details(
     request: Request,
     session: Session = Depends(get_session),

--- a/src/system.py
+++ b/src/system.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm.session import Session
 from auth_utils import get_auth_implicit_scheme, get_user
 from cache import cache_response
 from database import get_gsp_system, get_session
-from utils import limiter, N_CALLS_PER_HOUR
+from utils import N_CALLS_PER_HOUR, limiter
 
 # flake8: noqa: E501
 logger = structlog.stdlib.get_logger()

--- a/src/utils.py
+++ b/src/utils.py
@@ -17,7 +17,7 @@ logger = structlog.stdlib.get_logger()
 europe_london_tz = timezone("Europe/London")
 utc = timezone("UTC")
 limiter = Limiter(key_func=get_remote_address)
-N_CALLS_PER_HOUR = 5
+N_CALLS_PER_HOUR = 3600
 
 
 def floor_30_minutes_dt(dt):

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,8 +1,5 @@
 """ Utils functions for main.py """
 import os
-from slowapi import Limiter
-from slowapi.util import get_remote_address
-
 from datetime import datetime, timedelta
 from typing import List, Optional, Union
 
@@ -10,6 +7,8 @@ import numpy as np
 import structlog
 from nowcasting_datamodel.models import Forecast
 from pytz import timezone
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 
 from pydantic_models import NationalForecastValue
 
@@ -18,7 +17,7 @@ logger = structlog.stdlib.get_logger()
 europe_london_tz = timezone("Europe/London")
 utc = timezone("UTC")
 limiter = Limiter(key_func=get_remote_address)
-N_CALLS_PER_HOUR = 3600
+N_CALLS_PER_HOUR = 5
 
 
 def floor_30_minutes_dt(dt):

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,8 @@
 """ Utils functions for main.py """
 import os
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
 from datetime import datetime, timedelta
 from typing import List, Optional, Union
 
@@ -14,6 +17,8 @@ logger = structlog.stdlib.get_logger()
 
 europe_london_tz = timezone("Europe/London")
 utc = timezone("UTC")
+limiter = Limiter(key_func=get_remote_address)
+N_CALLS_PER_HOUR = 3600
 
 
 def floor_30_minutes_dt(dt):


### PR DESCRIPTION
# Pull Request

## Description

Add a rate limit of 3600 per hour, or 1 a second on each route, for each IP address.
Ive used [slowapi](https://github.com/laurentS/slowapi), could have use [fastapi-limiter](https://pypi.org/project/fastapi-limiter/) but it needed a redis query

#136 

## How Has This Been Tested?

- CI tests
- run locally and check limit kicks in
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
