### PR TITLE
Remove now_casting Dataset Usage and Adjust GSP Endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ pydantic
 numpy
 requests
 nowcasting_datamodel==1.5.18
-nowcasting_dataset==3.7.12
 sqlalchemy
 psycopg2-binary
 geopandas

--- a/src/system.py
+++ b/src/system.py
@@ -21,6 +21,7 @@ logger = structlog.stdlib.get_logger()
 router = APIRouter()
 NationalYield = GSPYield
 
+
 # corresponds to API route /v0/system/GB/gsp/, get system details for all GSPs
 @router.get(
     "/",


### PR DESCRIPTION
# Pull Request

## Description

Removed the `nowcasting_dataset` from `requirements.txt` and also its usage from [system.py](https://github.com/openclimatefix/uk-pv-national-gsp-api/blob/main/src/system.py)


Fixes #314 

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
