### PR TITLE
Update docs to make regime optional

### DIFF
--- a/src/gsp.py
+++ b/src/gsp.py
@@ -241,15 +241,16 @@ def get_truths_for_all_gsps(
     Setting the _regime_ parameter to _day-after_ includes
     the previous day's truth values for the GSPs.
 
-    If _regime_ is not specified, the parameter defaults to _in-day_.
+    If _regime_ is not specified, the parameter defaults to None and returns PV Live Updated
+    values where available, falling back to available PV Live Estimated values.
 
     If _compact_ is set to true, the response will be a list of GSPGenerations objects.
     This return object is significantly smaller, but less readable.
 
     #### Parameters
-    - **regime**: can choose __in-day__ or __day-after__
-    - **start_datetime_utc**: optional start datetime for the query.
-    - **end_datetime_utc**: optional end datetime for the query.
+    - **regime**: (optional) can choose __in-day__ or __day-after__
+    - **start_datetime_utc**: (optional) start datetime for the query.
+    - **end_datetime_utc**: (optional) end datetime for the query.
     """
     logger.info(f"Get PV Live estimates values for all gsp id and regime {regime} for user {user}")
 


### PR DESCRIPTION
# Pull Request

## Description
`gsp/pvlive/all` route docs said it should default `regime` to `in-day` if not specified; in reality, it defaults to `None` and gives us the expected behaviour of returning PV Live Updated where available, with Estimated values as fallback.

## How Has This Been Tested?

- [x] Locally

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
