### PR TITLE
Change ordinary rate limit to 1 req/s and introduce new 'slow' rate l…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pull the docker image from
 docker pull openclimatefix/nowcasting_api:latest
 ```
 
-You will need to set the following environmental variables:
+You will need to set the following environment variables:
 - `AUTH0_DOMAIN` - The Auth0 domain which can be collected from the Applications/Applications tab. It should be something like
 'XXXXXXX.eu.auth0.com'
 - `AUTH0_API_AUDIENCE` - THE Auth0 api audience, this can be collected from the Applications/APIs tab. It should be something like
@@ -39,6 +39,10 @@ You will need to set the following environmental variables:
 - `LOGLEVEL` - The log level for the application.
 
 Note you will need a database set up at `DB_URL`. This should use the datamodel in [nowcasting_datamodel](https://github.com/openclimatefix/nowcasting_datamodel)
+
+There are several optional environment variables:
+- `N_CALLS_PER_HOUR` - API rate limit for most endpoints. Defaults to 3600 (1 per second).
+- `N_SLOW_CALLS_PER_HOUR` - API rate limit for slow endpoints. Defaults to 60 (1 per minute).
 
 ## Documentation
 

--- a/src/gsp.py
+++ b/src/gsp.py
@@ -27,7 +27,7 @@ from pydantic_models import (
     LocationWithGSPYields,
     OneDatetimeManyForecastValues,
 )
-from utils import N_CALLS_PER_HOUR, format_datetime, limiter
+from utils import N_CALLS_PER_HOUR, N_SLOW_CALLS_PER_HOUR, format_datetime, limiter
 
 GSP_TOTAL = 317
 
@@ -55,7 +55,7 @@ def is_fake():
     dependencies=[Depends(get_auth_implicit_scheme())],
 )
 @cache_response
-@limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
+@limiter.limit(f"{N_SLOW_CALLS_PER_HOUR}/hour")
 def get_all_available_forecasts(
     request: Request,
     historic: Optional[bool] = True,

--- a/src/utils.py
+++ b/src/utils.py
@@ -19,8 +19,9 @@ europe_london_tz = timezone("Europe/London")
 utc = timezone("UTC")
 
 limiter = Limiter(key_func=get_remote_address)
-N_CALLS_PER_HOUR = os.getenv("N_CALLS_PER_HOUR", 3600) # 1 call per second
-N_SLOW_CALLS_PER_HOUR = os.getenv("N_SLOW_CALLS_PER_HOUR", 60) # 1 call per minute
+N_CALLS_PER_HOUR = os.getenv("N_CALLS_PER_HOUR", 3600)  # 1 call per second
+N_SLOW_CALLS_PER_HOUR = os.getenv("N_SLOW_CALLS_PER_HOUR", 60)  # 1 call per minute
+
 
 def floor_30_minutes_dt(dt):
     """

--- a/src/utils.py
+++ b/src/utils.py
@@ -17,9 +17,10 @@ logger = structlog.stdlib.get_logger()
 
 europe_london_tz = timezone("Europe/London")
 utc = timezone("UTC")
-limiter = Limiter(key_func=get_remote_address)
-N_CALLS_PER_HOUR = os.getenv("N_CALLS_PER_HOUR", 60)
 
+limiter = Limiter(key_func=get_remote_address)
+N_CALLS_PER_HOUR = os.getenv("N_CALLS_PER_HOUR", 3600) # 1 call per second
+N_SLOW_CALLS_PER_HOUR = os.getenv("N_SLOW_CALLS_PER_HOUR", 60) # 1 call per minute
 
 def floor_30_minutes_dt(dt):
     """


### PR DESCRIPTION
…imit for longer running calls

# Pull Request

## Description
* Introduces new environment variable 'N_SLOW_CALLS_PER_HOUR' to match 'N_CALLS_PER_HOUR'.
* Change default N_CALLS_PER_HOUR rate limit to 1 req/s and N_SLOW_CALLS_PER_HOUR to 1 req/minute
* Apply the slow rate limit to the endpoint which fetches all forecasts.
* Updates the README to add these both as optional environment variables.
Fixes #382 

## How Has This Been Tested?

Re-ran the python tests locally. Haven't introduced new tests as the rate limiting comes from an external library.

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
