### PR TITLE
Fix: Return HTTP 404 when file does not exist

### DIFF
--- a/src/status.py
+++ b/src/status.py
@@ -91,8 +91,7 @@ def update_last_data(
         try:
             gsp = query.one()
         except NoResultFound:
-            raise HTTPException(
-                status_code=404, detail="There are no gsp yields")
+            raise HTTPException(status_code=404, detail="There are no gsp yields")
 
         modified_date = gsp.created_utc
 
@@ -105,8 +104,7 @@ def update_last_data(
 
         # Check if the file exists before accessing it
         if not fs.exists(file):
-            raise HTTPException(
-                status_code=404, detail=f"File '{file}' not found")
+            raise HTTPException(status_code=404, detail=f"File '{file}' not found")
 
         modified_date = fs.modified(file)
 

--- a/src/status.py
+++ b/src/status.py
@@ -91,7 +91,8 @@ def update_last_data(
         try:
             gsp = query.one()
         except NoResultFound:
-            raise HTTPException(status_code=404, detail="There are no gsp yields")
+            raise HTTPException(
+                status_code=404, detail="There are no gsp yields")
 
         modified_date = gsp.created_utc
 
@@ -101,6 +102,12 @@ def update_last_data(
 
         # get modified date, this will probably be in s3
         fs = fsspec.open(file).fs
+
+        # Check if the file exists before accessing it
+        if not fs.exists(file):
+            raise HTTPException(
+                status_code=404, detail=f"File '{file}' not found")
+
         modified_date = fs.modified(file)
 
     # get last value


### PR DESCRIPTION
# Pull Request

## Description

This PR adds a check to verify whether the requested file exists before attempting to access it. If the file does not exist, the API now returns an HTTP `404 Not Found` error instead of failing with an internal server error. 

Fixes #392 

## How Has This Been Tested?

- [x] Extended existing test cases to cover scenarios where the requested file does not exist.
- [x] Verified that the new checks do not break existing functionality

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Data processing is not affected, as this change only modifies error handling.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)  
- [x] I have performed a self-review of my own code  
- [x] I have made corresponding changes to the documentation  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] I have checked my code and corrected any misspellings  
