### PR TITLE
Don't set default start time for single gsp forecast/all

### DIFF
--- a/nowcasting_api/gsp.py
+++ b/nowcasting_api/gsp.py
@@ -99,8 +99,8 @@ def get_all_available_forecasts(
     end_datetime_utc = format_datetime(end_datetime_utc)
     creation_limit_utc = format_datetime(creation_limit_utc)
 
-    # by default, don't get any data in the past
-    if start_datetime_utc is None:
+    # by default, don't get any data in the past if more than one gsp
+    if start_datetime_utc is None and (gsp_ids is None or len(gsp_ids) > 1):
         start_datetime_utc = floor_30_minutes_dt(datetime.now(tz=timezone.utc))
 
     forecasts = get_forecasts_from_database(


### PR DESCRIPTION
# Pull Request

## Description

Amend default behaviour, at least in short term, to correct lack of forecast in GSP chart in Quartz Solar UI.

Fixes https://github.com/openclimatefix/quartz-frontend/issues/560

## How Has This Been Tested?

- [x] Locally with API + UI

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
