### PR TITLE
add solar eclipse adjustments for 29_03_2025

### DIFF
--- a/nowcasting_api/national.py
+++ b/nowcasting_api/national.py
@@ -165,10 +165,10 @@ def get_national_forecast(
     
     # Adjust values for solar eclipse 2025-03-28
     eclipse_adjustments = {
-        '2025-03-29 10:30:00+00:00': 200,
-        '2025-03-29 11:00:00+00:00': 1000,
-        '2025-03-29 11:30:00+00:00': 1500,
-        '2025-03-29 12:00:00+00:00': 400,
+        '2025-03-29 10:30:00+00:00': 0.97,
+        '2025-03-29 11:00:00+00:00': 0.85,
+        '2025-03-29 11:30:00+00:00': 0.82,
+        '2025-03-29 12:00:00+00:00': 0.95,
     }
 
     # Reduce national forecast value by eclipse adjustment for matching datetimes
@@ -178,7 +178,7 @@ def get_national_forecast(
         
         for eclipse_time, reduction in eclipse_adjustments.items():
             if target_dt == pd.to_datetime(eclipse_time):
-                forecast_value.expected_power_generation_megawatts -= reduction
+                forecast_value.expected_power_generation_megawatts *= reduction
 
     if get_plevels:
         for forecast_value in national_forecast_values:
@@ -187,8 +187,8 @@ def get_national_forecast(
             
             for eclipse_time, reduction in eclipse_adjustments.items():
                 if target_dt == pd.to_datetime(eclipse_time):
-                    forecast_value.plevels['plevel_10'] -= reduction
-                    forecast_value.plevels['plevel_90'] -= reduction
+                    forecast_value.plevels['plevel_10'] *= reduction
+                    forecast_value.plevels['plevel_90'] *= reduction
 
     if include_metadata:
         # return full forecast object

--- a/nowcasting_api/national.py
+++ b/nowcasting_api/national.py
@@ -162,20 +162,20 @@ def get_national_forecast(
             format_plevels(national_forecast_value)
 
             national_forecast_values.append(national_forecast_value)
-    
+
     # Adjust values for solar eclipse 2025-03-28
     eclipse_adjustments = {
-        '2025-03-29 10:30:00+00:00': 0.97,
-        '2025-03-29 11:00:00+00:00': 0.85,
-        '2025-03-29 11:30:00+00:00': 0.82,
-        '2025-03-29 12:00:00+00:00': 0.95,
+        "2025-03-29 10:30:00+00:00": 0.97,
+        "2025-03-29 11:00:00+00:00": 0.85,
+        "2025-03-29 11:30:00+00:00": 0.82,
+        "2025-03-29 12:00:00+00:00": 0.95,
     }
 
     # Reduce national forecast value by eclipse adjustment for matching datetimes
     for forecast_value in national_forecast_values:
         target_time = forecast_value.target_time
         target_dt = pd.to_datetime(target_time)
-        
+
         for eclipse_time, reduction in eclipse_adjustments.items():
             if target_dt == pd.to_datetime(eclipse_time):
                 forecast_value.expected_power_generation_megawatts *= reduction
@@ -184,11 +184,11 @@ def get_national_forecast(
         for forecast_value in national_forecast_values:
             target_time = forecast_value.target_time
             target_dt = pd.to_datetime(target_time)
-            
+
             for eclipse_time, reduction in eclipse_adjustments.items():
                 if target_dt == pd.to_datetime(eclipse_time):
-                    forecast_value.plevels['plevel_10'] *= reduction
-                    forecast_value.plevels['plevel_90'] *= reduction
+                    forecast_value.plevels["plevel_10"] *= reduction
+                    forecast_value.plevels["plevel_90"] *= reduction
 
     if include_metadata:
         # return full forecast object

--- a/nowcasting_api/national.py
+++ b/nowcasting_api/national.py
@@ -162,6 +162,34 @@ def get_national_forecast(
             format_plevels(national_forecast_value)
 
             national_forecast_values.append(national_forecast_value)
+    
+    # Adjust values for solar eclipse 2025-03-28
+    eclipse_adjustments = {
+        '2025-03-29 10:30:00+00:00': 200,
+        '2025-03-29 11:00:00+00:00': 1000,
+        '2025-03-29 11:30:00+00:00': 1500,
+        '2025-03-29 12:00:00+00:00': 400,
+    }
+
+    # Reduce national forecast value by eclipse adjustment for matching datetimes
+    for forecast_value in national_forecast_values:
+        target_time = forecast_value.target_time
+        target_dt = pd.to_datetime(target_time)
+        
+        for eclipse_time, reduction in eclipse_adjustments.items():
+            if target_dt == pd.to_datetime(eclipse_time):
+                forecast_value.expected_power_generation_megawatts -= reduction
+
+    if get_plevels:
+        for forecast_value in national_forecast_values:
+            target_time = forecast_value.target_time
+            target_dt = pd.to_datetime(target_time)
+            
+            for eclipse_time, reduction in eclipse_adjustments.items():
+                if target_dt == pd.to_datetime(eclipse_time):
+                    forecast_value.plevels['plevel_10'] -= reduction
+                    forecast_value.plevels['plevel_90'] -= reduction
+
     if include_metadata:
         # return full forecast object
         forecast.forecast_values = national_forecast_values


### PR DESCRIPTION
Adjust values to account for partial solar eclipse on 29/03/2025.

When the get_national_forecast function is used by the API the following values are reduced 

`    eclipse_adjustments = {
        '2025-03-29 10:30:00+00:00': 200,
        '2025-03-29 11:00:00+00:00': 1000,
        '2025-03-29 11:30:00+00:00': 1500,
        '2025-03-29 12:00:00+00:00': 400,
    }
`

I've checked this works as expected locally


## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
