### PR TITLE
Update national.py

### DIFF
--- a/nowcasting_api/national.py
+++ b/nowcasting_api/national.py
@@ -103,7 +103,7 @@ def get_national_forecast(
     - **creation_limit_utc**: optional, only return forecasts made before this datetime.
     Note you can only go 7 days back at the moment
     - **model_name**: optional, specify which model to use for the forecast.
-    Options: blend (default), pvnet_intraday, pvnet_day_ahead, pvnet_intraday_ecmwf
+    Options: blend (default), pvnet_intraday, pvnet_day_ahead, pvnet_intraday_ecmwf_only
 
     Returns:
         dict: The national forecast data.

--- a/nowcasting_api/national.py
+++ b/nowcasting_api/national.py
@@ -46,13 +46,13 @@ elexon_forecast_api = GenerationForecastApi(api_client)
 class ModelName(str, Enum):
     """Available model options for national forecasts.
 
-    Options include blend (default), pvnet_intraday, pvnet_day_ahead, and pvnet_intraday_ecmwf.
+    Options include blend (default), pvnet_intraday, pvnet_day_ahead, and pvnet_intraday_ecmwf_only.
     """
 
     blend = "blend"
     pvnet_intraday = "pvnet_v2"
     pvnet_day_ahead = "pvnet_day_ahead"
-    pvnet_intraday_ecmwf = "pvnet_ecmwf"
+    pvnet_intraday_ecmwf_only = "pvnet_ecmwf"
 
 
 @router.get(

--- a/nowcasting_api/national.py
+++ b/nowcasting_api/national.py
@@ -46,13 +46,13 @@ elexon_forecast_api = GenerationForecastApi(api_client)
 class ModelName(str, Enum):
     """Available model options for national forecasts.
 
-    Options include blend (default), pvnet_v2, pvnet_da, and pvnet_ecwmf.
+    Options include blend (default), pvnet_intraday, pvnet_day_ahead, and pvnet_intraday_ecmwf.
     """
 
     blend = "blend"
-    pvnet_v2 = "pvnet_v2"
-    pvnet_da = "pvnet_da"
-    pvnet_ecwmf = "pvnet_ecwmf"
+    pvnet_intraday = "pvnet_v2"
+    pvnet_day_ahead = "pvnet_day_ahead"
+    pvnet_intraday_ecmwf = "pvnet_ecmwf"
 
 
 @router.get(
@@ -95,7 +95,7 @@ def get_national_forecast(
     - **creation_limit_utc**: optional, only return forecasts made before this datetime.
     Note you can only go 7 days back at the moment
     - **model_name**: optional, specify which model to use for the forecast.
-    Options: blend (default), pvnet_v2, pvnet_da, pvnet_ecwmf
+    Options: blend (default), pvnet_intraday, pvnet_day_ahead, pvnet_intraday_ecmwf
 
     Returns:
         dict: The national forecast data.

--- a/nowcasting_api/national.py
+++ b/nowcasting_api/national.py
@@ -43,6 +43,14 @@ api_client = ApiClient()
 elexon_forecast_api = GenerationForecastApi(api_client)
 
 
+model_names_external_to_internal = {
+    "blend": "blend",
+    "pvnet_intraday": "pvnet_v2",
+    "pvnet_day_ahead": "pvnet_day_ahead",
+    "pvnet_intraday_ecmwf_only": "pvnet_ecmwf",
+}
+
+
 class ModelName(str, Enum):
     """Available model options for national forecasts.
 
@@ -50,9 +58,9 @@ class ModelName(str, Enum):
     """
 
     blend = "blend"
-    pvnet_intraday = "pvnet_v2"
+    pvnet_intraday = "pvnet_intraday"
     pvnet_day_ahead = "pvnet_day_ahead"
-    pvnet_intraday_ecmwf_only = "pvnet_ecmwf"
+    pvnet_intraday_ecmwf_only = "pvnet_intraday_ecmwf_only"
 
 
 @router.get(
@@ -106,6 +114,8 @@ def get_national_forecast(
     start_datetime_utc = format_datetime(start_datetime_utc)
     end_datetime_utc = format_datetime(end_datetime_utc)
     creation_limit_utc = format_datetime(creation_limit_utc)
+
+    model_name = model_names_external_to_internal.get(model_name)
 
     logger.debug(f"Getting forecast using model {model_name}")
     if include_metadata:


### PR DESCRIPTION
# Pull Request

## Description

Update the model names related to the different models producing forecasts which can be pulled via the API.

Model names are: blend (default), pvnet_intraday, pvnet_day_ahead, and pvnet_intraday_ecmwf_only.

Fixes #

pvnet_da changed to pvnet_day_ahead.

pvnet_ecmwf fixed spelling.

## How Has This Been Tested?

@peterdudfield testing locally.

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
