### PR TITLE
dont through 404 error when checking last forecast run

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ You will need to set the following environment variables:
 - `ORIGINS` - Endpoints that are valid CORS origins. See [FastAPI documentation](https://fastapi.tiangolo.com/tutorial/cors/).
 - `N_HISTORY_DAYS` - Default is just to load data from today and yesterday,
     but we can set this to 5, if we want the api always to return 5 days of data
-- `FORECAST_ERROR_HOURS` - using route `/v0/system/GBstatus/check_last_forecast_run` we can check if a forecast has
-        been made in the last `FORECAST_ERROR_HOURS` hours
 - `ADJUST_MW_LIMIT` - the maximum the api is allowed to adjust the national forecast by
 - `FAKE` - This allows fake data to be used, rather than connecting to a database
 - `QUERY_WAIT_SECONDS` - The number of seconds to wait for an on going query

--- a/nowcasting_api/status.py
+++ b/nowcasting_api/status.py
@@ -21,8 +21,6 @@ logger = structlog.stdlib.get_logger()
 
 router = APIRouter()
 
-forecast_error_hours = float(os.getenv("FORECAST_ERROR_HOURS", 2.0))
-
 
 @router.get("/status", response_model=Status)
 @cache_response
@@ -65,15 +63,6 @@ def check_last_forecast(
         if model_name is not None:
             message += f" for model {model_name}"
         raise HTTPException(status_code=404, detail=message)
-
-    if forecast.forecast_creation_time <= datetime.now(tz=timezone.utc) - timedelta(
-        hours=forecast_error_hours
-    ):
-        raise HTTPException(
-            status_code=404,
-            detail=f"The last forecast is more than {forecast_error_hours} hours ago. "
-            f"It was made at {forecast.forecast_creation_time}",
-        )
 
     logger.debug(f"Last forecast time was {forecast.forecast_creation_time}")
     return forecast.forecast_creation_time

--- a/nowcasting_api/tests/test_status.py
+++ b/nowcasting_api/tests/test_status.py
@@ -109,20 +109,6 @@ def test_check_last_forecast_run_correct_wrong_model_name(db_session):
 
 
 @freeze_time("2023-01-03")
-def test_check_last_forecast_error(db_session):
-    """Check check_last_forecast_run gives error"""
-    forecast_creation_time = datetime.now(tz=timezone.utc) - timedelta(hours=3)
-    forecast = ForecastSQL(forecast_creation_time=forecast_creation_time)
-    db_session.add(forecast)
-    db_session.commit()
-
-    app.dependency_overrides[get_session] = lambda: db_session
-
-    response = client.get("/v0/solar/GB/check_last_forecast_run")
-    assert response.status_code == 404
-
-
-@freeze_time("2023-01-03")
 def test_check_last_forecast_gsp(db_session):
     """Check check_last_forecast_run works fine"""
 


### PR DESCRIPTION
# Pull Request

## Description

Dont put 404 error when checking last foreacts run

#401 

## How Has This Been Tested?

CI tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
