### PR TITLE
Changing N_SLOW_CALLS timeframe to minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Note you will need a database set up at `DB_URL`. This should use the datamodel 
 
 There are several optional environment variables:
 - `N_CALLS_PER_HOUR` - API rate limit for most endpoints. Defaults to 3600 (1 per second).
-- `N_SLOW_CALLS_PER_HOUR` - API rate limit for slow endpoints. Defaults to 60 (1 per minute).
+- `N_SLOW_CALLS_PER_MINUTE` - API rate limit for slow endpoints. Defaults to 1 (1 per minute).
 
 ## Documentation
 

--- a/nowcasting_api/gsp.py
+++ b/nowcasting_api/gsp.py
@@ -28,7 +28,7 @@ from pydantic_models import (
 from sqlalchemy.orm.session import Session
 from utils import (
     N_CALLS_PER_HOUR,
-    N_SLOW_CALLS_PER_HOUR,
+    N_SLOW_CALLS_PER_MINUTE,
     floor_30_minutes_dt,
     format_datetime,
     limiter,
@@ -55,7 +55,7 @@ NationalYield = GSPYield
     dependencies=[Depends(get_auth_implicit_scheme())],
 )
 @cache_response
-@limiter.limit(f"{N_SLOW_CALLS_PER_HOUR}/hour")
+@limiter.limit(f"{N_SLOW_CALLS_PER_MINUTE}/minute")
 def get_all_available_forecasts(
     request: Request,
     historic: Optional[bool] = True,

--- a/nowcasting_api/tests/test_gsp.py
+++ b/nowcasting_api/tests/test_gsp.py
@@ -20,7 +20,7 @@ from nowcasting_datamodel.save.update import update_all_forecast_latest
 from nowcasting_api.database import get_session
 from nowcasting_api.main import app
 from nowcasting_api.pydantic_models import GSPYieldGroupByDatetime, OneDatetimeManyForecastValues
-from nowcasting_api.utils import floor_30_minutes_dt
+from nowcasting_api.utils import floor_30_minutes_dt, N_SLOW_CALLS_PER_MINUTE
 
 
 @freeze_time("2022-01-01")
@@ -421,3 +421,30 @@ def test_read_truths_for_all_gsp_compact(db_session, api_client):
     assert len(datetimes_with_gsp_yields[0].generation_kw_by_gsp_id) == 1
     assert len(datetimes_with_gsp_yields[1].generation_kw_by_gsp_id) == 2
     assert len(datetimes_with_gsp_yields[2].generation_kw_by_gsp_id) == 1
+
+
+def test_slow_rate_limit_exceeded(db_session, api_client):
+    """ Check a 429 is thrown if the slow rate limit is exceeded """
+
+    _ = get_model(session=db_session, name="blend", version="0.0.1")
+
+    _ = make_fake_forecasts(
+        gsp_ids=list(range(0, 10)),
+        model_name="blend",
+        session=db_session,
+        add_latest=True,
+        t0_datetime_utc=floor_30_minutes_dt(datetime.now(tz=UTC)),
+    )
+
+    db_session.commit()
+
+    app.dependency_overrides[get_session] = lambda: db_session
+
+    # Call gsp/forecast/all/ more times than the rate limit
+    responses = [
+        api_client.get("/v0/solar/GB/gsp/forecast/all/?historic=False")
+        for _ in range(int(N_SLOW_CALLS_PER_MINUTE) + 1)
+    ]
+
+    # Check for at least 1 429 - there could be more as this route is called in earlier tests
+    assert any(r.status_code == 429 for r in responses)

--- a/nowcasting_api/tests/test_gsp.py
+++ b/nowcasting_api/tests/test_gsp.py
@@ -20,7 +20,7 @@ from nowcasting_datamodel.save.update import update_all_forecast_latest
 from nowcasting_api.database import get_session
 from nowcasting_api.main import app
 from nowcasting_api.pydantic_models import GSPYieldGroupByDatetime, OneDatetimeManyForecastValues
-from nowcasting_api.utils import floor_30_minutes_dt, N_SLOW_CALLS_PER_MINUTE
+from nowcasting_api.utils import N_SLOW_CALLS_PER_MINUTE, floor_30_minutes_dt
 
 
 @freeze_time("2022-01-01")

--- a/nowcasting_api/tests/test_gsp.py
+++ b/nowcasting_api/tests/test_gsp.py
@@ -424,7 +424,7 @@ def test_read_truths_for_all_gsp_compact(db_session, api_client):
 
 
 def test_slow_rate_limit_exceeded(db_session, api_client):
-    """ Check a 429 is thrown if the slow rate limit is exceeded """
+    """Check a 429 is thrown if the slow rate limit is exceeded"""
 
     _ = get_model(session=db_session, name="blend", version="0.0.1")
 

--- a/nowcasting_api/utils.py
+++ b/nowcasting_api/utils.py
@@ -19,7 +19,7 @@ utc = timezone("UTC")
 
 limiter = Limiter(key_func=get_remote_address)
 N_CALLS_PER_HOUR = os.getenv("N_CALLS_PER_HOUR", 3600)  # 1 call per second
-N_SLOW_CALLS_PER_HOUR = os.getenv("N_SLOW_CALLS_PER_HOUR", 60)  # 1 call per minute
+N_SLOW_CALLS_PER_MINUTE = os.getenv("N_SLOW_CALLS_PER_MINUTE", 1)  # 1 call per minute
 
 
 def floor_30_minutes_dt(dt):

--- a/test-docker-compose.yml
+++ b/test-docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - LOG_LEVEL=DEBUG
       - DELETE_CACHE_TIME_SECONDS=0
       - CACHE_TIME_SECONDS=0
+      - N_SLOW_CALLS_PER_MINUTE=20
     command: >
       bash -c "pytest --cov=./nowcasting_api
       && coverage report -m


### PR DESCRIPTION
# Pull Request

## Description

Resolving Issue 423 - changing the rate limiting to a per minute basis, defaulting to 1 call per minute https://github.com/openclimatefix/uk-pv-national-gsp-api/issues/423.

Fixes:

- Changed `N_SLOW_CALLS_PER_HOUR` (default 60 per hour)  to `N_SLOW_CALLS_PER_MINUTE` (default 1 per minute)
- Added `N_SLOW_CALLS_PER_MINUTE` as an environment variable in `test-docker-compose.yml` to prevent rate limiting during the pytests. Have just set this to 20 arbitrarily. 

## How Has This Been Tested?

I ran the pytests via the readme instructions, they're all passing. 

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
