### PR TITLE
Add tests to prevent PV Live GSP route regression behaviour

### DIFF
--- a/nowcasting_api/tests/test_gsp.py
+++ b/nowcasting_api/tests/test_gsp.py
@@ -290,6 +290,12 @@ def test_read_truths_for_a_specific_gsp(db_session, api_client):
     _ = [GSPYield(**gsp_yield) for gsp_yield in r_json]
 
 
+# N.B. These e2e tests won't test every edge case, but they will test the main functionality,
+# and that the API is returning the expected data.
+# More thorough integration tests can be found in the datamodel:
+# https://github.com/openclimatefix/nowcasting_datamodel/blob/main/tests/read/test_read_gsp.py
+
+
 @freeze_time("2022-01-02 12:10:00")
 def test_read_truths_for_specific_gsp_with_start_datetime(db_session, api_client):
     """Check main solar/GB/gsp/{gsp_id}/pvlive route works with start_datetime_utc"""
@@ -308,19 +314,19 @@ def test_read_truths_for_specific_gsp_with_start_datetime(db_session, api_client
     )
     gsp_yield_4_sql = gsp_yield_4.to_orm()
 
-    gsp_sql_1: LocationSQL = Location(
+    location_sql_1: LocationSQL = Location(
         gsp_id=122, label="GSP_122", status_interval_minutes=5
     ).to_orm()
 
     # add pv system to yield object
-    gsp_yield_1_sql.location = gsp_sql_1
-    gsp_yield_2_sql.location = gsp_sql_1
-    gsp_yield_3_sql.location = gsp_sql_1
-    gsp_yield_4_sql.location = gsp_sql_1
+    gsp_yield_1_sql.location = location_sql_1
+    gsp_yield_2_sql.location = location_sql_1
+    gsp_yield_3_sql.location = location_sql_1
+    gsp_yield_4_sql.location = location_sql_1
 
     # add to database
     db_session.add_all(
-        [gsp_yield_1_sql, gsp_yield_2_sql, gsp_yield_3_sql, gsp_yield_4_sql, gsp_sql_1]
+        [gsp_yield_1_sql, gsp_yield_2_sql, gsp_yield_3_sql, gsp_yield_4_sql, location_sql_1]
     )
     db_session.commit()
 
@@ -357,17 +363,17 @@ def test_read_truths_for_specific_gsp_with_regime_day_after(db_session, api_clie
     )
     gsp_yield_3_sql = gsp_yield_3.to_orm()
 
-    gsp_sql_1: LocationSQL = Location(
+    location_sql_1: LocationSQL = Location(
         gsp_id=122, label="GSP_122", status_interval_minutes=5
     ).to_orm()
 
     # add pv system to yield object
-    gsp_yield_1_sql.location = gsp_sql_1
-    gsp_yield_2_sql.location = gsp_sql_1
-    gsp_yield_3_sql.location = gsp_sql_1
+    gsp_yield_1_sql.location = location_sql_1
+    gsp_yield_2_sql.location = location_sql_1
+    gsp_yield_3_sql.location = location_sql_1
 
     # add to database
-    db_session.add_all([gsp_yield_1_sql, gsp_yield_2_sql, gsp_yield_3_sql, gsp_sql_1])
+    db_session.add_all([gsp_yield_1_sql, gsp_yield_2_sql, gsp_yield_3_sql, location_sql_1])
     db_session.commit()
 
     app.dependency_overrides[get_session] = lambda: db_session
@@ -401,17 +407,17 @@ def test_read_truths_for_specific_gsp_with_regime_in_day_explicitly(db_session, 
     )
     gsp_yield_3_sql = gsp_yield_3.to_orm()
 
-    gsp_sql_1: LocationSQL = Location(
+    location_sql_1: LocationSQL = Location(
         gsp_id=122, label="GSP_122", status_interval_minutes=5
     ).to_orm()
 
     # add pv system to yield object
-    gsp_yield_1_sql.location = gsp_sql_1
-    gsp_yield_2_sql.location = gsp_sql_1
-    gsp_yield_3_sql.location = gsp_sql_1
+    gsp_yield_1_sql.location = location_sql_1
+    gsp_yield_2_sql.location = location_sql_1
+    gsp_yield_3_sql.location = location_sql_1
 
     # add to database
-    db_session.add_all([gsp_yield_1_sql, gsp_yield_2_sql, gsp_yield_3_sql, gsp_sql_1])
+    db_session.add_all([gsp_yield_1_sql, gsp_yield_2_sql, gsp_yield_3_sql, location_sql_1])
     db_session.commit()
 
     app.dependency_overrides[get_session] = lambda: db_session
@@ -483,22 +489,29 @@ def setup_gsp_yield_data(db_session):
     gsp_yield_4 = GSPYield(datetime_utc=datetime(2022, 1, 1, 12), solar_generation_kw=3)
     gsp_yield_4_sql = gsp_yield_4.to_orm()
 
-    gsp_sql_1: LocationSQL = Location(
+    location_sql_1: LocationSQL = Location(
         gsp_id=122, label="GSP_122", status_interval_minutes=5
     ).to_orm()
-    gsp_sql_2: LocationSQL = Location(
+    location_sql_2: LocationSQL = Location(
         gsp_id=123, label="GSP_123", status_interval_minutes=10
     ).to_orm()
 
     # add pv system to yield object
-    gsp_yield_1_sql.location = gsp_sql_1
-    gsp_yield_2_sql.location = gsp_sql_1
-    gsp_yield_3_sql.location = gsp_sql_2
-    gsp_yield_4_sql.location = gsp_sql_1
+    gsp_yield_1_sql.location = location_sql_1
+    gsp_yield_2_sql.location = location_sql_1
+    gsp_yield_3_sql.location = location_sql_2
+    gsp_yield_4_sql.location = location_sql_1
 
     # add to database
     db_session.add_all(
-        [gsp_yield_1_sql, gsp_yield_2_sql, gsp_yield_3_sql, gsp_yield_4_sql, gsp_sql_1, gsp_sql_2]
+        [
+            gsp_yield_1_sql,
+            gsp_yield_2_sql,
+            gsp_yield_3_sql,
+            gsp_yield_4_sql,
+            location_sql_1,
+            location_sql_2,
+        ]
     )
     db_session.commit()
 

--- a/nowcasting_api/tests/test_gsp.py
+++ b/nowcasting_api/tests/test_gsp.py
@@ -284,6 +284,8 @@ def test_read_truths_for_a_specific_gsp(db_session, api_client):
 
     r_json = response.json()
     assert len(r_json) == 3
+    # Also check the returned date format
+    assert r_json[0]["datetimeUtc"] == "2022-01-02T00:00:00Z"
 
     _ = [GSPYield(**gsp_yield) for gsp_yield in r_json]
 
@@ -332,6 +334,8 @@ def test_read_truths_for_specific_gsp_with_start_datetime(db_session, api_client
 
     # Should exclude the first yield (before the start_datetime_utc) and last yield (day-after)
     assert len(r_json) == 2
+    # Also check the returned date format
+    assert r_json[0]["datetimeUtc"] == "2022-01-02T00:00:00Z"
 
     _ = [GSPYield(**gsp_yield) for gsp_yield in r_json]
 
@@ -376,6 +380,8 @@ def test_read_truths_for_specific_gsp_with_regime_day_after(db_session, api_clie
 
     # Should exclude the first yield as it has a regime of "in-day" by default
     assert len(r_json) == 2
+    # Also check the returned date format
+    assert r_json[0]["datetimeUtc"] == "2022-01-02T00:00:00Z"
 
     _ = [GSPYield(**gsp_yield) for gsp_yield in r_json]
 
@@ -418,6 +424,8 @@ def test_read_truths_for_specific_gsp_with_regime_in_day_explicitly(db_session, 
 
     # Should exclude the last yield as it has a regime of "day-after"
     assert len(r_json) == 2
+    # Also check the returned date format
+    assert r_json[0]["datetimeUtc"] == "2022-01-01T12:00:00Z"
 
     _ = [GSPYield(**gsp_yield) for gsp_yield in r_json]
 


### PR DESCRIPTION
# Pull Request

## Description

~Fix bugs introduced in #432 regarding PV Live GSP endpoint/functions.~ (PR reverted)

Seems that in the recent refactor, some required behaviour (route params e.g. start_datetime / regime) were omitted completely, and other behaviour was odd/incorrect; this should now be fixed, and brought more in line with previous behaviour from the datamodel, while keeping the new typehinting.
 
Add tests to prevent this happening again (and fix existing ones that seem to have been pointing at the incorrect API routes for some time 😅)

Fixes #435

## How Has This Been Tested?

- [x] Added new test scenarios for route and params

- [x] Checked through local API into local UI


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
