### PR TITLE
Bug/nation include metadata

### DIFF
--- a/nowcasting_api/national.py
+++ b/nowcasting_api/national.py
@@ -147,6 +147,11 @@ def get_national_forecast(
         )
         forecast = forecast[0]
 
+        # if initialization_datetime_utc is not set, set it to the same as forecast_creation_time
+        # This can be removed later when the forecast starts writing initialization_datetime_utc
+        if forecast.initialization_datetime_utc is None:
+            forecast.initialization_datetime_utc = forecast.forecast_creation_time
+
         if historic:
             forecast = NationalForecast.from_orm_latest(forecast)
         else:


### PR DESCRIPTION
# Pull Request

## Description

Add fix for when `initialization_datetime_utc` is not set

#448 

## How Has This Been Tested?

- [x] Ci tests
- [x] tested local route `http://127.0.0.1:8000/v0/solar/GB/national/forecast?include_metadata=true`

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
