### PR TITLE
Remove duplicates

### DIFF
--- a/nowcasting_api/database.py
+++ b/nowcasting_api/database.py
@@ -42,7 +42,12 @@ from pydantic_models import (
     convert_location_sql_to_many_datetime_many_generation,
 )
 from sqlalchemy.orm.session import Session
-from utils import filter_forecast_values, floor_30_minutes_dt, get_start_datetime, remove_duplicate_values
+from utils import (
+    filter_forecast_values,
+    floor_30_minutes_dt,
+    get_start_datetime,
+    remove_duplicate_values,
+)
 
 
 class BaseDBConnection(abc.ABC):

--- a/nowcasting_api/database.py
+++ b/nowcasting_api/database.py
@@ -42,7 +42,7 @@ from pydantic_models import (
     convert_location_sql_to_many_datetime_many_generation,
 )
 from sqlalchemy.orm.session import Session
-from utils import filter_forecast_values, floor_30_minutes_dt, get_start_datetime
+from utils import filter_forecast_values, floor_30_minutes_dt, get_start_datetime, remove_duplicate_values
 
 
 class BaseDBConnection(abc.ABC):
@@ -243,6 +243,8 @@ def get_forecasts_from_database(
             forecasts=forecasts,
             start_datetime_utc=start_datetime_utc,
         )
+
+        forecasts = remove_duplicate_values(forecasts=forecasts)
 
         # return as many forecasts
         return ManyForecasts(forecasts=forecasts)

--- a/nowcasting_api/tests/test_utils.py
+++ b/nowcasting_api/tests/test_utils.py
@@ -4,15 +4,15 @@ import os
 from datetime import datetime, timezone
 
 from freezegun import freeze_time
-
-from nowcasting_api.pydantic_models import NationalForecastValue
 from nowcasting_datamodel.models.forecast import (
     Forecast,
-    Location,
-    MLModel,
     ForecastValue,
     InputDataLastUpdated,
+    Location,
+    MLModel,
 )
+
+from nowcasting_api.pydantic_models import NationalForecastValue
 from nowcasting_api.utils import (
     floor_30_minutes_dt,
     format_plevels,

--- a/nowcasting_api/utils.py
+++ b/nowcasting_api/utils.py
@@ -215,3 +215,34 @@ def filter_forecast_values(
             forecasts_filtered.append(forecast)
         forecasts = forecasts_filtered
     return forecasts
+
+def remove_duplicate_values(forecasts: List[Forecast]) -> List[Forecast]:
+    """
+    Remove duplicate values from the forecast values of target time
+
+    We assume that the first target time is the one we keep
+    Note: This could be done in the database query, too, but currently this quiet hard as
+    we get this values from a join, and use forecast.forecast_values
+
+    :param forecasts: list of forecasts
+    :return: list of forecasts with duplicate values removed
+    """
+    forecasts_filtered = []
+    for forecast in forecasts:
+
+        # create a dict of distinct times:forecast_values
+        # note we reverse the order so that the top value is keep
+        distinct_times_dict = {fv.target_time: fv for fv in forecast.forecast_values[::-1]}
+        # change back to a list
+        forecast_values = [v for k, v in distinct_times_dict.items()]
+
+        # sort by target time
+        forecast_values = sorted(forecast_values, key=lambda x: x.target_time)
+
+        forecast.forecast_values = forecast_values
+
+        forecasts_filtered.append(forecast)
+
+    return forecasts_filtered
+
+

--- a/nowcasting_api/utils.py
+++ b/nowcasting_api/utils.py
@@ -230,18 +230,21 @@ def remove_duplicate_values(forecasts: List[Forecast]) -> List[Forecast]:
     forecasts_filtered = []
     for forecast in forecasts:
 
-        # create a dict of distinct times:forecast_values
-        # note we reverse the order so that the top value is keep
-        distinct_times_dict = {fv.target_time: fv for fv in forecast.forecast_values[::-1]}
-        # change back to a list
-        forecast_values = [v for k, v in distinct_times_dict.items()]
+        # check to see if there are any duplicates
+        if len(forecast.forecast_values) == len(set([fv.target_time for fv in forecast.forecast_values])):
+            forecasts_filtered.append(forecast)
+        else:
+            # create a dict of {target_times:forecast_values}
+            # note we reverse the order so that the top value is keep
+            distinct_times_dict = {fv.target_time: fv for fv in forecast.forecast_values[::-1]}
+            # change back to a list
+            forecast_values = [v for k, v in distinct_times_dict.items()]
 
-        # sort by target time
-        forecast_values = sorted(forecast_values, key=lambda x: x.target_time)
+            # sort by target time, because we reverse the target times earlier
+            forecast_values = sorted(forecast_values, key=lambda x: x.target_time)
 
-        forecast.forecast_values = forecast_values
-
-        forecasts_filtered.append(forecast)
+            forecast.forecast_values = forecast_values
+            forecasts_filtered.append(forecast)
 
     return forecasts_filtered
 

--- a/nowcasting_api/utils.py
+++ b/nowcasting_api/utils.py
@@ -216,6 +216,7 @@ def filter_forecast_values(
         forecasts = forecasts_filtered
     return forecasts
 
+
 def remove_duplicate_values(forecasts: List[Forecast]) -> List[Forecast]:
     """
     Remove duplicate values from the forecast values of target time
@@ -231,7 +232,9 @@ def remove_duplicate_values(forecasts: List[Forecast]) -> List[Forecast]:
     for forecast in forecasts:
 
         # check to see if there are any duplicates
-        if len(forecast.forecast_values) == len(set([fv.target_time for fv in forecast.forecast_values])):
+        if len(forecast.forecast_values) == len(
+            set([fv.target_time for fv in forecast.forecast_values])
+        ):
             forecasts_filtered.append(forecast)
         else:
             # create a dict of {target_times:forecast_values}
@@ -247,5 +250,3 @@ def remove_duplicate_values(forecasts: List[Forecast]) -> List[Forecast]:
             forecasts_filtered.append(forecast)
 
     return forecasts_filtered
-
-


### PR DESCRIPTION
# Pull Request

## Description

Occacisioanly there are multe value for target_time, gsp_id, and model_name in the forecast_value_latest. This can happen when we upgrade a model, then the API will provide this duplicates when 
- pulling national data with include_data
- non compact for forecast/all.
- but not for all other routes

This PR solves that 
Helps solve #450 

Speed did not significantly change

## How Has This Been Tested?

- [x] CI test
- [x] tested locally

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
