### PR TITLE
speed up forecast all

### DIFF
--- a/nowcasting_api/database_fast.py
+++ b/nowcasting_api/database_fast.py
@@ -13,7 +13,7 @@ def get_forecast_values_all_compact(
     end_datetime_utc: datetime | None = None,
     gsp_ids=None,
 ) -> [OneDatetimeManyForecastValues]:
-    """"
+    """ "
     Get forecast values from the database.
 
     This function

--- a/nowcasting_api/database_fast.py
+++ b/nowcasting_api/database_fast.py
@@ -13,8 +13,7 @@ def get_forecast_values_all_compact(
     end_datetime_utc: datetime | None = None,
     gsp_ids=None,
 ) -> [OneDatetimeManyForecastValues]:
-    """ "
-    Get forecast values from the database.
+    """ Get forecast values from the database.
 
     This function
     1. get model ids

--- a/nowcasting_api/database_fast.py
+++ b/nowcasting_api/database_fast.py
@@ -1,9 +1,9 @@
+""" Get data from database - optimized"""
 from datetime import datetime
 
 from nowcasting_datamodel.models import ForecastValueLatestSQL, MLModelSQL
-from sqlalchemy.orm.session import Session
-
 from pydantic_models import OneDatetimeManyForecastValues
+from sqlalchemy.orm.session import Session
 
 
 def get_forecast_values_all_compact(
@@ -22,12 +22,11 @@ def get_forecast_values_all_compact(
     3. converts to a dict of {datetime: {gsp_id: forecast_value}}
     4. converts to a list of OneDatetimeManyForecastValues objects
     """
-
-    #
+    # 1. get model ids
     model_ids = session.query(MLModelSQL.id).filter(MLModelSQL.name == "blend").all()
     model_ids = [model_id[0] for model_id in model_ids]
 
-    # get forecast values from database
+    # 2. get forecast values from database
     query = session.query(
         ForecastValueLatestSQL.target_time,
         ForecastValueLatestSQL.expected_power_generation_megawatts,
@@ -60,7 +59,7 @@ def get_forecast_values_all_compact(
 
     forecast_values = query.all()
 
-    # convert to OneDatetimeManyForecastValues
+    # 3. convert to OneDatetimeManyForecastValues
     many_forecast_values_by_datetime = {}
 
     # loop over locations and gsp yields to create a dictionary of gsp generation by datetime
@@ -77,7 +76,7 @@ def get_forecast_values_all_compact(
         else:
             many_forecast_values_by_datetime[datetime_utc][gsp_id] = power_kw
 
-    # convert dictionary to list of OneDatetimeManyForecastValues objects
+    # 4. convert dictionary to list of OneDatetimeManyForecastValues objects
     many_forecast_values = []
     for datetime_utc, forecast_values in many_forecast_values_by_datetime.items():
         many_forecast_values.append(

--- a/nowcasting_api/database_fast.py
+++ b/nowcasting_api/database_fast.py
@@ -17,7 +17,7 @@ def get_forecast_values_all_compact(
 
     We get all the latest forecast values for the blend model.
     We convert the sqlalchemy objects to OneDatetimeManyForecastValues
-    Particular focus has been put on only get the data we need from the database. 
+    Particular focus has been put on only get the data we need from the database.
 
     This function
     1. get model ids

--- a/nowcasting_api/database_fast.py
+++ b/nowcasting_api/database_fast.py
@@ -15,6 +15,10 @@ def get_forecast_values_all_compact(
 ) -> [OneDatetimeManyForecastValues]:
     """ Get forecast values from the database.
 
+    We get all the latest forecast values for the blend model.
+    We convert the sqlalchemy objects to OneDatetimeManyForecastValues
+    Particular focus has been put on only get the data we need from the database. 
+
     This function
     1. get model ids
     2. get forecast values from the forecast_value_latest table.

--- a/nowcasting_api/database_fast.py
+++ b/nowcasting_api/database_fast.py
@@ -1,10 +1,9 @@
-from nowcasting_datamodel.models import ForecastValueLatestSQL, MLModelSQL
+from datetime import datetime
 
+from nowcasting_datamodel.models import ForecastValueLatestSQL, MLModelSQL
 from sqlalchemy.orm.session import Session
 
 from pydantic_models import OneDatetimeManyForecastValues
-
-from datetime import datetime
 
 
 def get_forecast_values_all_compact(
@@ -40,14 +39,17 @@ def get_forecast_values_all_compact(
 
     # join with model table
     query = query.filter(ForecastValueLatestSQL.model_id.in_(model_ids))
-    # query = query.filter(ForecastValueLatestSQL.forecast_id.in_(forecast_ids))
 
     if start_datetime_utc is not None:
         query = query.filter(ForecastValueLatestSQL.target_time >= start_datetime_utc)
     if end_datetime_utc is not None:
         query = query.filter(ForecastValueLatestSQL.target_time <= end_datetime_utc)
+
     if gsp_ids is not None:
         query = query.filter(ForecastValueLatestSQL.gsp_id.in_(gsp_ids))
+    else:
+        # dont get gps id 0
+        query = query.filter(ForecastValueLatestSQL.gsp_id != 0)
 
     # order by target time and created utc desc
     query = query.order_by(
@@ -56,7 +58,6 @@ def get_forecast_values_all_compact(
         ForecastValueLatestSQL.created_utc.desc(),
     )
 
-    print(f"Getting forecast_value")
     forecast_values = query.all()
 
     # convert to OneDatetimeManyForecastValues

--- a/nowcasting_api/database_fast.py
+++ b/nowcasting_api/database_fast.py
@@ -1,0 +1,88 @@
+from nowcasting_datamodel.models import ForecastValueLatestSQL, MLModelSQL
+
+from sqlalchemy.orm.session import Session
+
+from pydantic_models import OneDatetimeManyForecastValues
+
+from datetime import datetime
+
+
+def get_forecast_values_all_compact(
+    session: Session,
+    start_datetime_utc: datetime | None = None,
+    end_datetime_utc: datetime | None = None,
+    gsp_ids=None,
+) -> [OneDatetimeManyForecastValues]:
+    """"
+    Get forecast values from the database.
+
+    This function
+    1. get model ids
+    2. get forecast values from the forecast_value_latest table.
+        We tried to only get the relevant data as needed, as this is normally a larger query
+    3. converts to a dict of {datetime: {gsp_id: forecast_value}}
+    4. converts to a list of OneDatetimeManyForecastValues objects
+    """
+
+    #
+    model_ids = session.query(MLModelSQL.id).filter(MLModelSQL.name == "blend").all()
+    model_ids = [model_id[0] for model_id in model_ids]
+
+    # get forecast values from database
+    query = session.query(
+        ForecastValueLatestSQL.target_time,
+        ForecastValueLatestSQL.expected_power_generation_megawatts,
+        ForecastValueLatestSQL.gsp_id,
+    )
+
+    # distinct on target_time
+    query = query.distinct(ForecastValueLatestSQL.gsp_id, ForecastValueLatestSQL.target_time)
+
+    # join with model table
+    query = query.filter(ForecastValueLatestSQL.model_id.in_(model_ids))
+    # query = query.filter(ForecastValueLatestSQL.forecast_id.in_(forecast_ids))
+
+    if start_datetime_utc is not None:
+        query = query.filter(ForecastValueLatestSQL.target_time >= start_datetime_utc)
+    if end_datetime_utc is not None:
+        query = query.filter(ForecastValueLatestSQL.target_time <= end_datetime_utc)
+    if gsp_ids is not None:
+        query = query.filter(ForecastValueLatestSQL.gsp_id.in_(gsp_ids))
+
+    # order by target time and created utc desc
+    query = query.order_by(
+        ForecastValueLatestSQL.gsp_id,
+        ForecastValueLatestSQL.target_time,
+        ForecastValueLatestSQL.created_utc.desc(),
+    )
+
+    print(f"Getting forecast_value")
+    forecast_values = query.all()
+
+    # convert to OneDatetimeManyForecastValues
+    many_forecast_values_by_datetime = {}
+
+    # loop over locations and gsp yields to create a dictionary of gsp generation by datetime
+    for forecast_value in forecast_values:
+        datetime_utc = forecast_value[0]
+        power_kw = forecast_value[1]
+        gsp_id = forecast_value[2]
+
+        power_kw = round(power_kw, 2)
+
+        # if the datetime object is not in the dictionary, add it
+        if datetime_utc not in many_forecast_values_by_datetime:
+            many_forecast_values_by_datetime[datetime_utc] = {gsp_id: power_kw}
+        else:
+            many_forecast_values_by_datetime[datetime_utc][gsp_id] = power_kw
+
+    # convert dictionary to list of OneDatetimeManyForecastValues objects
+    many_forecast_values = []
+    for datetime_utc, forecast_values in many_forecast_values_by_datetime.items():
+        many_forecast_values.append(
+            OneDatetimeManyForecastValues(
+                datetime_utc=datetime_utc, forecast_values=forecast_values
+            )
+        )
+
+    return many_forecast_values

--- a/nowcasting_api/database_fast.py
+++ b/nowcasting_api/database_fast.py
@@ -1,4 +1,5 @@
 """ Get data from database - optimized"""
+
 from datetime import datetime
 
 from nowcasting_datamodel.models import ForecastValueLatestSQL, MLModelSQL

--- a/nowcasting_api/gsp.py
+++ b/nowcasting_api/gsp.py
@@ -7,7 +7,6 @@ from typing import List, Optional, Union
 import structlog
 from auth_utils import get_auth_implicit_scheme, get_user
 from cache import cache_response
-from database_fast import get_forecast_values_all_compact
 from database import (
     get_forecasts_from_database,
     get_latest_forecast_values_for_a_specific_gsp_from_database,
@@ -15,6 +14,7 @@ from database import (
     get_truth_values_for_a_specific_gsp_from_database,
     get_truth_values_for_all_gsps_from_database,
 )
+from database_fast import get_forecast_values_all_compact
 from dotenv import load_dotenv
 from fastapi import APIRouter, Depends, Request, Security, status
 from fastapi.responses import Response

--- a/nowcasting_api/gsp.py
+++ b/nowcasting_api/gsp.py
@@ -111,7 +111,8 @@ def get_all_available_forecasts(
             session=session,
             start_datetime_utc=start_datetime_utc,
             end_datetime_utc=end_datetime_utc,
-            gsp_ids=gsp_ids)
+            gsp_ids=gsp_ids,
+        )
 
     forecasts = get_forecasts_from_database(
         session=session,


### PR DESCRIPTION
# Pull Request

## Description

- speed up forecast all, this is just for compact=True and no creation time limit. This will help the UI.

Speed ups are
| route | current [s] | new [s] |
| --- | --- | --- |
| `/gsp/forecast/all/?compact=true`  | 3.67 | 1.15 |
| `/gsp/forecast/all/?compact=true&start_datetime_utc=2025-05-16T10:00:18&end_datetime_utc=2025-05-16T11:00:18`  | 10.7 | 1.17 |

Helps with #455 

## How Has This Been Tested?

- [x] Ci tests
- [x] ran locally

Ran UAT checks currently in https://github.com/openclimatefix/airflow-dags/pull/193, 
and two forecast/all checks go down from 9 seconds to ~1 second


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
