### PR TITLE
add typing for `gsp_ids` in database_fast.py

### DIFF
--- a/nowcasting_api/database_fast.py
+++ b/nowcasting_api/database_fast.py
@@ -38,9 +38,7 @@ def get_forecast_values_all_compact(
     )
 
     # distinct on target_time
-    query = query.distinct(
-        ForecastValueLatestSQL.gsp_id, ForecastValueLatestSQL.target_time
-    )
+    query = query.distinct(ForecastValueLatestSQL.gsp_id, ForecastValueLatestSQL.target_time)
 
     # join with model table
     query = query.filter(ForecastValueLatestSQL.model_id.in_(model_ids))

--- a/nowcasting_api/database_fast.py
+++ b/nowcasting_api/database_fast.py
@@ -1,4 +1,4 @@
-""" Get data from database - optimized"""
+"""Get data from database - optimized"""
 
 from datetime import datetime
 
@@ -11,8 +11,8 @@ def get_forecast_values_all_compact(
     session: Session,
     start_datetime_utc: datetime | None = None,
     end_datetime_utc: datetime | None = None,
-    gsp_ids=None,
-) -> [OneDatetimeManyForecastValues]:
+    gsp_ids: list[str] | None = None,
+) -> list[OneDatetimeManyForecastValues]:
     """Get forecast values from the database.
 
     We get all the latest forecast values for the blend model.
@@ -38,7 +38,9 @@ def get_forecast_values_all_compact(
     )
 
     # distinct on target_time
-    query = query.distinct(ForecastValueLatestSQL.gsp_id, ForecastValueLatestSQL.target_time)
+    query = query.distinct(
+        ForecastValueLatestSQL.gsp_id, ForecastValueLatestSQL.target_time
+    )
 
     # join with model table
     query = query.filter(ForecastValueLatestSQL.model_id.in_(model_ids))
@@ -51,7 +53,7 @@ def get_forecast_values_all_compact(
     if gsp_ids is not None:
         query = query.filter(ForecastValueLatestSQL.gsp_id.in_(gsp_ids))
     else:
-        # dont get gps id 0
+        # dont get gsp id 0
         query = query.filter(ForecastValueLatestSQL.gsp_id != 0)
 
     # order by target time and created utc desc


### PR DESCRIPTION
# Pull Request

## Description

* add typing for `gsp_ids` and for the function output
* address issue #458 originating from the discussion in https://github.com/openclimatefix/uk-pv-national-gsp-api/pull/456#pullrequestreview-2847068399 

Fixes #
* add type annotation for `gsp_ids` as `list[str] | None`
* updates type annotation for function output as `list[OneDatetimeManyForecastValues]`
* fix: typo in comments, `gps id 0 --> gsp id 0`

## How Has This Been Tested?
as this change was just annotating types, I didn't test this. (but please let me know if this would be necessary and I'll do it!)

- [ ] Yes

## Checklist:

- [X] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked my code and corrected any misspellings
