### PR TITLE
sort forecasts, before removing duplicates

### DIFF
--- a/nowcasting_api/national.py
+++ b/nowcasting_api/national.py
@@ -159,7 +159,6 @@ def get_national_forecast(
         if forecast.initialization_datetime_utc is None:
             forecast.initialization_datetime_utc = forecast.forecast_creation_time
 
-
         if historic:
             # make sure forecast.forecast_value_latest are order by target_time and created_utc desc
             # this means we get a list of target times descending, and for each target time

--- a/nowcasting_api/national.py
+++ b/nowcasting_api/national.py
@@ -159,7 +159,21 @@ def get_national_forecast(
         if forecast.initialization_datetime_utc is None:
             forecast.initialization_datetime_utc = forecast.forecast_creation_time
 
+
         if historic:
+            # make sure forecast.forecast_value_latest are order by target_time and created_utc desc
+            # this means we get a list of target times descending, and for each target time
+            # the most recent created_utc value is at the top
+            forecast.forecast_values_latest = sorted(
+                forecast.forecast_values_latest,
+                key=lambda x: x.created_utc,
+                reverse=True,
+            )
+            forecast.forecast_values_latest = sorted(
+                forecast.forecast_values_latest,
+                key=lambda x: x.target_time,
+            )
+
             forecast = NationalForecast.from_orm_latest(forecast)
         else:
             forecast = NationalForecast.from_orm(forecast)

--- a/nowcasting_api/tests/test_national.py
+++ b/nowcasting_api/tests/test_national.py
@@ -163,11 +163,9 @@ def test_get_national_forecast_duplicate_values(db_session, api_client):
     national_forecast = NationalForecast(**response.json())
     assert len(national_forecast.forecast_values) == (24 * 2 + 8) * 2
     assert national_forecast.forecast_values[0].plevels is not None
-    # index 24 is the middle of the day
-    assert (
-        national_forecast.forecast_values[24].plevels["plevel_10"]
-        != national_forecast.forecast_values[0].expected_power_generation_megawatts * 0.9
-    )
+    assert national_forecast.forecast_values[24].expected_power_generation_megawatts \
+           == forecast2.forecast_values[24].expected_power_generation_megawatts
+
 
 
 @freeze_time("2024-01-01")

--- a/nowcasting_api/tests/test_national.py
+++ b/nowcasting_api/tests/test_national.py
@@ -165,10 +165,12 @@ def test_get_national_forecast_duplicate_values(db_session, api_client):
     assert response.status_code == 200
 
     national_forecast = NationalForecast(**response.json())
+    # 2 days + 8 hours + 1 due to forecast 2 being 30 mins later
     assert len(national_forecast.forecast_values) == (24 * 2 + 8) * 2 + 1
     assert national_forecast.forecast_values[0].plevels is not None
 
     # let's make sure we get at least one value in the day
+    # we use idx-1 for forecast 2 due to it being 30 minutes later than the first forecast
     for idx  in [6,12,18,24]:
         assert national_forecast.forecast_values[idx].target_time == forecast2.forecast_values[idx-1].target_time
         assert national_forecast.forecast_values[idx].expected_power_generation_megawatts \

--- a/nowcasting_api/tests/test_national.py
+++ b/nowcasting_api/tests/test_national.py
@@ -1,6 +1,6 @@
 """ Test for main app """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import numpy as np
 from freezegun import freeze_time
@@ -13,6 +13,7 @@ from nowcasting_datamodel.save.update import update_all_forecast_latest
 from nowcasting_api.database import get_session
 from nowcasting_api.main import app
 from nowcasting_api.pydantic_models import NationalForecast, NationalForecastValue
+from nowcasting_api.utils import floor_30_minutes_dt
 
 
 def test_read_latest_national_values(db_session, api_client):
@@ -135,25 +136,28 @@ def test_get_national_forecast(db_session, api_client):
     )
 
 
-@freeze_time("2024-01-01")
 def test_get_national_forecast_duplicate_values(db_session, api_client):
     """Check main solar/GB/national/forecast route works with duplicate values"""
 
+    t0 = floor_30_minutes_dt(datetime.now())
     model1 = get_model(db_session, name="blend", version="0.0.1")
-    model2 = get_model(db_session, name="blend", version="0.0.2")
-
     forecast1 = make_fake_national_forecast(
-        session=db_session, t0_datetime_utc=datetime.now(tz=timezone.utc)
+        session=db_session, t0_datetime_utc=t0
     )
     forecast1.model = model1
+
+    db_session.add(forecast1)
+    update_all_forecast_latest(forecasts=[forecast1], session=db_session)
+
+    # add second model values
+    model2 = get_model(db_session, name="blend", version="0.0.2")
     forecast2 = make_fake_national_forecast(
-        session=db_session, t0_datetime_utc=datetime.now(tz=timezone.utc)
+        session=db_session, t0_datetime_utc=t0 + timedelta(minutes=30)
     )
     forecast2.model = model2
 
-    db_session.add(forecast1)
     db_session.add(forecast2)
-    update_all_forecast_latest(forecasts=[forecast1, forecast2], session=db_session)
+    update_all_forecast_latest(forecasts=[forecast2], session=db_session)
 
     app.dependency_overrides[get_session] = lambda: db_session
 
@@ -161,10 +165,14 @@ def test_get_national_forecast_duplicate_values(db_session, api_client):
     assert response.status_code == 200
 
     national_forecast = NationalForecast(**response.json())
-    assert len(national_forecast.forecast_values) == (24 * 2 + 8) * 2
+    assert len(national_forecast.forecast_values) == (24 * 2 + 8) * 2 + 1
     assert national_forecast.forecast_values[0].plevels is not None
-    assert national_forecast.forecast_values[24].expected_power_generation_megawatts \
-           == forecast2.forecast_values[24].expected_power_generation_megawatts
+
+    # let's make sure we get at least one value in the day
+    for idx  in [6,12,18,24]:
+        assert national_forecast.forecast_values[idx].target_time == forecast2.forecast_values[idx-1].target_time
+        assert national_forecast.forecast_values[idx].expected_power_generation_megawatts \
+               == round(forecast2.forecast_values[idx-1].expected_power_generation_megawatts,2)
 
 
 

--- a/nowcasting_api/tests/test_national.py
+++ b/nowcasting_api/tests/test_national.py
@@ -169,10 +169,14 @@ def test_get_national_forecast_duplicate_values(db_session, api_client):
 
     # let's make sure we get at least one value in the day
     # we use idx-1 for forecast 2 due to it being 30 minutes later than the first forecast
-    for idx  in [6,12,18,24]:
-        assert national_forecast.forecast_values[idx].target_time == forecast2.forecast_values[idx-1].target_time
-        assert national_forecast.forecast_values[idx].expected_power_generation_megawatts \
-               == round(forecast2.forecast_values[idx-1].expected_power_generation_megawatts,2)
+    for idx in [6, 12, 18, 24]:
+        assert (
+            national_forecast.forecast_values[idx].target_time
+            == forecast2.forecast_values[idx - 1].target_time
+        )
+        assert national_forecast.forecast_values[idx].expected_power_generation_megawatts == round(
+            forecast2.forecast_values[idx - 1].expected_power_generation_megawatts, 2
+        )
 
 
 @freeze_time("2024-01-01")

--- a/nowcasting_api/utils.py
+++ b/nowcasting_api/utils.py
@@ -224,6 +224,7 @@ def remove_duplicate_values(forecasts: List[Forecast]) -> List[Forecast]:
     We assume that the first target time is the one we keep
     Note: This could be done in the database query, too, but currently this quiet hard as
     we get this values from a join, and use forecast.forecast_values
+    or forecast.forecast_value_latest
 
     :param forecasts: list of forecasts
     :return: list of forecasts with duplicate values removed
@@ -237,9 +238,16 @@ def remove_duplicate_values(forecasts: List[Forecast]) -> List[Forecast]:
         ):
             forecasts_filtered.append(forecast)
         else:
+
+            # order forecast_values by created_time desc,
+            # so that the latest created_utcs are first
+            forecast_values = sorted(
+                forecast.forecast_values, key=lambda x: x.created_utc, reverse=True
+            )
+
             # create a dict of {target_times:forecast_values}
             # note we reverse the order so that the top value is keep
-            distinct_times_dict = {fv.target_time: fv for fv in forecast.forecast_values[::-1]}
+            distinct_times_dict = {fv.target_time: fv for fv in forecast_values[::-1]}
             # change back to a list
             forecast_values = [v for k, v in distinct_times_dict.items()]
 

--- a/nowcasting_api/utils.py
+++ b/nowcasting_api/utils.py
@@ -240,7 +240,7 @@ def remove_duplicate_values(forecasts: List[Forecast]) -> List[Forecast]:
         else:
             # create a dict of {target_times:forecast_values}
             # note we reverse the order so that the top value is keep
-            distinct_times_dict = {fv.target_time: fv for fv in forecast_values[::-1]}
+            distinct_times_dict = {fv.target_time: fv for fv in forecast.forecast_values[::-1]}
             # change back to a list
             forecast_values = [v for k, v in distinct_times_dict.items()]
 

--- a/nowcasting_api/utils.py
+++ b/nowcasting_api/utils.py
@@ -238,13 +238,6 @@ def remove_duplicate_values(forecasts: List[Forecast]) -> List[Forecast]:
         ):
             forecasts_filtered.append(forecast)
         else:
-
-            # order forecast_values by created_time desc,
-            # so that the latest created_utcs are first
-            forecast_values = sorted(
-                forecast.forecast_values, key=lambda x: x.created_utc, reverse=True
-            )
-
             # create a dict of {target_times:forecast_values}
             # note we reverse the order so that the top value is keep
             distinct_times_dict = {fv.target_time: fv for fv in forecast_values[::-1]}


### PR DESCRIPTION
# Pull Request

## Description

- make sure forecast values are order by created_utc desc before removing duplicates

note: think this happend before due to forecast.forecast_value_latest not strictly being returned in created_utc order. 

Would be nice to re-write this database query to make it super clear what is happening. This is part of #467. We can imagine we pull the national_forecast_values for metadata_false, and then we get the forecast data separately. This needs a bit of a rewrite, so I would rather get this PR through first and test it on dev when we deploy a new ml model. 

#477 

## How Has This Been Tested?

- [x] CI tests
- [x] added a new test
- [x] comment out the code changes and checked test failed

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
