### PR TITLE
Make sure start_datetime is set in /gsp/forecast/all

### DIFF
--- a/nowcasting_api/database_fast.py
+++ b/nowcasting_api/database_fast.py
@@ -21,6 +21,8 @@ from sqlalchemy import NUMERIC
 from sqlalchemy.orm import Query
 from sqlalchemy.orm.session import Session
 
+from nowcasting_api.utils import get_start_datetime
+
 adjust_limit = float(os.getenv("ADJUST_MW_LIMIT", 0.0))
 
 
@@ -59,6 +61,9 @@ def get_forecast_values_all_compact(
 
     # join with model table
     query = query.filter(ForecastValueLatestSQL.model_id.in_(model_ids))
+
+    # make sure start time is set, and is not before the max history length
+    start_datetime_utc = get_start_datetime(start_datetime=start_datetime_utc)
 
     # filters
     query = filter_start_and_end_datetime(

--- a/nowcasting_api/database_fast.py
+++ b/nowcasting_api/database_fast.py
@@ -21,8 +21,6 @@ from sqlalchemy import NUMERIC
 from sqlalchemy.orm import Query
 from sqlalchemy.orm.session import Session
 
-from nowcasting_api.utils import get_start_datetime
-
 adjust_limit = float(os.getenv("ADJUST_MW_LIMIT", 0.0))
 
 
@@ -61,9 +59,6 @@ def get_forecast_values_all_compact(
 
     # join with model table
     query = query.filter(ForecastValueLatestSQL.model_id.in_(model_ids))
-
-    # make sure start time is set, and is not before the max history length
-    start_datetime_utc = get_start_datetime(start_datetime=start_datetime_utc)
 
     # filters
     query = filter_start_and_end_datetime(

--- a/nowcasting_api/gsp.py
+++ b/nowcasting_api/gsp.py
@@ -32,6 +32,7 @@ from utils import (
     N_SLOW_CALLS_PER_HOUR,
     floor_30_minutes_dt,
     format_datetime,
+    get_start_datetime,
     limiter,
 )
 
@@ -104,10 +105,13 @@ def get_all_available_forecasts(
     if start_datetime_utc is None and (gsp_ids is None or len(gsp_ids) > 1):
         start_datetime_utc = floor_30_minutes_dt(datetime.now(tz=timezone.utc))
 
-    # Lets start by spending up no creation limit.
-    # There are other speed ups, we could of course do, but this is a good start.
+    # Let's start by speeding up no creation limit.
+    # There are other speed-ups, we could of course do, but this is a good start.
     if creation_limit_utc is None and historic:
         if compact:
+            # make sure start time is set, and is not before the max history length
+            start_datetime_utc = get_start_datetime(start_datetime=start_datetime_utc)
+
             return get_forecast_values_all_compact(
                 session=session,
                 start_datetime_utc=start_datetime_utc,

--- a/nowcasting_api/gsp.py
+++ b/nowcasting_api/gsp.py
@@ -104,14 +104,14 @@ def get_all_available_forecasts(
     # by default, don't get any data in the past if more than one gsp
     if start_datetime_utc is None and (gsp_ids is None or len(gsp_ids) > 1):
         start_datetime_utc = floor_30_minutes_dt(datetime.now(tz=timezone.utc))
+    else:
+        # make sure start time is set, and is not before the max history length
+        start_datetime_utc = get_start_datetime(start_datetime=start_datetime_utc)
 
     # Let's start by speeding up no creation limit.
     # There are other speed-ups, we could of course do, but this is a good start.
     if creation_limit_utc is None and historic:
         if compact:
-            # make sure start time is set, and is not before the max history length
-            start_datetime_utc = get_start_datetime(start_datetime=start_datetime_utc)
-
             return get_forecast_values_all_compact(
                 session=session,
                 start_datetime_utc=start_datetime_utc,


### PR DESCRIPTION
# Pull Request

## Description

Add missing start_datetime check in newly optimised /gsp/forecast/all

Fixes #483 

## How Has This Been Tested?

- [x] Running locally on API + UI

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
