### PR TITLE
Removed the @cache_response decorator from the 'get_status' function.

### DIFF
--- a/nowcasting_api/status.py
+++ b/nowcasting_api/status.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 import fsspec
 import structlog
-from cache import cache_response
 from database import get_latest_status_from_database, get_session, save_api_call_to_db
 from fastapi import APIRouter, Depends, HTTPException, Request
 from nowcasting_datamodel.models import ForecastSQL, GSPYieldSQL, MLModelSQL, Status
@@ -22,7 +21,6 @@ router = APIRouter()
 
 
 @router.get("/status", response_model=Status)
-@cache_response
 @limiter.limit(f"{N_CALLS_PER_HOUR}/hour")
 def get_status(request: Request, session: Session = Depends(get_session)) -> Status:
     """### Get status for the database and forecasts


### PR DESCRIPTION
…n in 'nowcasting_api/status.py' to allow the status API route to update immediately

# Pull Request

## Description


Removed @cache_response from the 'get_status' function in 'nowcasting_api/status.py' to allow the API status route to update immediately.

This pull request is related to the issue #480.
Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [*] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [*] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [*] I have checked my code and corrected any misspellings
