### PR TITLE
refactor

### DIFF
--- a/nowcasting_api/gsp.py
+++ b/nowcasting_api/gsp.py
@@ -180,7 +180,7 @@ def get_forecasts_for_a_specific_gsp_old_route(
 ) -> Union[Forecast, List[ForecastValue]]:
     """Redirects old API route to new route /v0/solar/GB/gsp/{gsp_id}/forecast"""
 
-    return get_forecasts_for_a_specific_gsp(
+    return get_forecasts_data_for_a_specific_gsp(
         request=request,
         gsp_id=gsp_id,
         session=session,
@@ -226,6 +226,50 @@ def get_forecasts_for_a_specific_gsp(
     - **start_datetime_utc**: optional start datetime for the query.
     - **end_datetime_utc**: optional end datetime for the query.
     - **creation_utc_limit**: optional, only return forecasts made before this datetime.
+    returns the latest forecast made 60 minutes before the target time)
+    """
+
+    return get_forecasts_data_for_a_specific_gsp(
+        request=request,
+        gsp_id=gsp_id,
+        session=session,
+        forecast_horizon_minutes=forecast_horizon_minutes,
+        user=user,
+        start_datetime_utc=start_datetime_utc,
+        end_datetime_utc=end_datetime_utc,
+        creation_limit_utc=creation_limit_utc,
+    )
+
+
+def get_forecasts_data_for_a_specific_gsp(
+    request: Request,
+    gsp_id: int,
+    session: Session = Depends(get_session),
+    forecast_horizon_minutes: Optional[int] = None,
+    user: Auth0User = Security(get_user()),
+    start_datetime_utc: Optional[str] = None,
+    end_datetime_utc: Optional[str] = None,
+    creation_limit_utc: Optional[str] = None,
+) -> Union[Forecast, List[ForecastValue]]:
+    """Get recent forecast values for a specific GSP
+
+    This function returns the most recent forecast for each _target_time_ for a
+    specific GSP.
+
+    The "forecast_horizon_minutes" parameter allows
+    a user to query for a forecast that is made this number, or horizon, of
+    minutes before the "target_time".
+
+    For example, if the target time is 10am today, the forecast made at 2am
+    today is the 8-hour forecast for 10am, and the forecast made at 6am for
+    10am today is the 4-hour forecast for 10am.
+
+    Parameters:
+    - gsp_id: *gsp_id* of the desired forecast
+    - forecast_horizon_minutes: optional forecast horizon in minutes (ex. 60
+    - start_datetime_utc: optional start datetime for the query.
+    - end_datetime_utc: optional end datetime for the query.
+    - creation_utc_limit: optional, only return forecasts made before this datetime.
     returns the latest forecast made 60 minutes before the target time)
     """
 

--- a/nowcasting_api/gsp.py
+++ b/nowcasting_api/gsp.py
@@ -265,11 +265,14 @@ def get_forecasts_data_for_a_specific_gsp(
     10am today is the 4-hour forecast for 10am.
 
     Parameters:
-    - gsp_id: *gsp_id* of the desired forecast
-    - forecast_horizon_minutes: optional forecast horizon in minutes (ex. 60
-    - start_datetime_utc: optional start datetime for the query.
-    - end_datetime_utc: optional end datetime for the query.
-    - creation_utc_limit: optional, only return forecasts made before this datetime.
+        :param: request: the request object
+        :param: session: the database session
+        :param: gsp_id: *gsp_id* of the desired forecast
+        :param: forecast_horizon_minutes: optional forecast horizon in minutes (ex. 60)
+        :param: user: the user making the request
+        :param: start_datetime_utc: optional start datetime for the query.
+        :param: end_datetime_utc: optional end datetime for the query.
+        :param: creation_utc_limit: optional, only return forecasts made before this datetime.
     returns the latest forecast made 60 minutes before the target time)
     """
 

--- a/nowcasting_api/gsp.py
+++ b/nowcasting_api/gsp.py
@@ -264,15 +264,14 @@ def get_forecasts_data_for_a_specific_gsp(
     today is the 8-hour forecast for 10am, and the forecast made at 6am for
     10am today is the 4-hour forecast for 10am.
 
-    Parameters:
-        :param: request: the request object
-        :param: session: the database session
-        :param: gsp_id: *gsp_id* of the desired forecast
-        :param: forecast_horizon_minutes: optional forecast horizon in minutes (ex. 60)
-        :param: user: the user making the request
-        :param: start_datetime_utc: optional start datetime for the query.
-        :param: end_datetime_utc: optional end datetime for the query.
-        :param: creation_utc_limit: optional, only return forecasts made before this datetime.
+    :param request: the request object
+    :param session: the database session
+    :param gsp_id: *gsp_id* of the desired forecast
+    :param forecast_horizon_minutes: optional forecast horizon in minutes (ex. 60)
+    :param user: the user making the request
+    :param start_datetime_utc: optional start datetime for the query.
+    :param end_datetime_utc: optional end datetime for the query.
+    :param creation_utc_limit: optional, only return forecasts made before this datetime.
     returns the latest forecast made 60 minutes before the target time)
     """
 


### PR DESCRIPTION
# Pull Request

## Description

Refactor `gsp/gsp_id/forecast` to pull data from new function. This means `gsp/forecast/gsp_id` and `gsp/gsp_id/forecast/` both get data from `get_forecasts_data_for_a_specific_gsp`

Currently, we reroute `gsp/gsp_id/forecast/` into `gsp/forecast/gsp_id` and i read this might lead a memory leak

Might help with #492 

## How Has This Been Tested?

- [x] CI test

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
