### PR TITLE
Pin FastAPI version to 0.116.1 to fix startup issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 opencv-contrib-python-headless
-fastapi
+fastapi==0.116.1
 uvicorn[standard]
 pydantic
 numpy


### PR DESCRIPTION
# Pull Request

## Description

This PR pins the FastAPI version in requirements.txt to 0.116.1 as requested in issue [#491 ]

Fixes #

## How Has This Been Tested?

Successfully rebuilt the Docker image using docker-compose up --build ,Verified the FastAPI app runs correctly at http://localhost:8000/ ,Accessed the Swagger documentation at /swagger to ensure API endpoints load properly,Confirmed no runtime errors or warnings in logs
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
